### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2015 SFS Toolbox Team
+Copyright (c) 2014-2015 SFS Toolbox contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2015 SFS Toolbox Developers
+Copyright (c) 2014-2015 SFS Toolbox Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
In the Matlab version and on the homepage I used the phrase `SFS Toolbox Team` for the copyright statements and would propose to use the same in the Python version.