### PR TITLE
Update doc to be hosted at python.sfstoolbox.org

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,9 +66,10 @@ intersphinx_mapping = {
 }
 
 # Definition of variables that are used by the versions.html theme file
-html_context = {'active_tab': 'matlab',
-                'home_url': 'http://matlab.sfstoolbox.org',
-                'github_url': 'http://github.com/sfstoolbox/sfs'}
+html_context = {'active_tab': 'python',
+                'nav_maxdepth': 3,
+                'home_url': 'http://python.sfstoolbox.org',
+                'github_url': 'http://github.com/sfstoolbox/sfs-python'}
 
 plot_include_source = True
 plot_html_show_source_link = False
@@ -85,7 +86,7 @@ source_suffix = '.rst'
 #source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = 'contents'
 
 # General information about the project.
 authors = 'SFS Toolbox Developers'
@@ -156,7 +157,7 @@ html_theme = 'sfs'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sfsdoc.get_theme_dir()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,7 @@
 
 import sys
 import os
+import sfsdoc
 from subprocess import check_output
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -63,6 +64,11 @@ intersphinx_mapping = {
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.sourceforge.net/', None),
 }
+
+# Definition of variables that are used by the versions.html theme file
+html_context = {'active_tab': 'matlab',
+                'home_url': 'http://matlab.sfstoolbox.org',
+                'github_url': 'http://github.com/sfstoolbox/sfs'}
 
 plot_include_source = True
 plot_html_show_source_link = False
@@ -142,7 +148,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sfs'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -1,0 +1,7 @@
+.. _contents:
+
+.. toctree::
+    :maxdepth: 2
+    :hidden:
+
+    index

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,10 +7,10 @@
 .. default-role::
 
 API Documentation
-=================
+-----------------
 
 Loudspeaker Arrays
-------------------
+^^^^^^^^^^^^^^^^^^
 
 .. automodule:: sfs.array
    :members:
@@ -18,62 +18,62 @@ Loudspeaker Arrays
    :exclude-members: ArrayData
 
 Tapering
---------
+^^^^^^^^
 
 .. automodule:: sfs.tapering
    :members:
    :undoc-members:
 
 Monochromatic Sources
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: sfs.mono.source
    :members:
    :undoc-members:
 
 Time Domain Sources
--------------------
+^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: sfs.time.source
    :members:
    :undoc-members:
 
 Monochromatic Driving Functions
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: sfs.mono.drivingfunction
    :members:
    :undoc-members:
 
 Monochromatic Sound Fields
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: sfs.mono.synthesized
    :members:
    :undoc-members:
    
 Time Domain Driving Functions
------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: sfs.time.drivingfunction
    :members:
    :undoc-members:
    
 Time Domain Sound Fields
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 .. automodule:: sfs.time.soundfield
    :members:
    :undoc-members:
 
 Plotting
---------
+^^^^^^^^
 
 .. automodule:: sfs.plot
    :members:
    :undoc-members:
 
 Utilities
----------
+^^^^^^^^^
 
 .. automodule:: sfs.util
    :members:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,5 @@
+-e git+https://github.com/sfstoolbox/sfs-documentation-theme.git#egg=SfsDoc
+
 jinja2
 pygments
 sphinx


### PR DESCRIPTION
* I incorporated the theme for the webpage (https://github.com/sfstoolbox/sfs-documentation-theme)
* I updated the hierachy of heading in index.rst as their should be only one h1 heading on a page (this causes also the strange behavior in the left menu on rtd)
* I added a contents.rst to be able to include a toctree, which is needed to generate navigation menus with specified maxdepth