### PR TITLE
Fix non-unit direction vectors

### DIFF
--- a/sfs/mono/drivingfunction.py
+++ b/sfs/mono/drivingfunction.py
@@ -86,7 +86,7 @@ def _wfs_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     """
     x0 = util.asarray_of_rows(x0)
     n0 = util.asarray_of_rows(n0)
-    n = util.asarray_1d(n)
+    n = util.normalize_vector(n)
     k = util.wavenumber(omega, c)
     return 2j * k * np.inner(n, n0) * np.exp(-1j * k * np.inner(n, x0))
 
@@ -106,7 +106,7 @@ def wfs_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None,
     """
     x0 = util.asarray_of_rows(x0)
     n0 = util.asarray_of_rows(n0)
-    n = util.asarray_1d(n)
+    n = util.normalize_vector(n)
     xref = util.asarray_1d(xref)
     k = util.wavenumber(omega, c)
     return wfs_25d_preeq(omega, omalias, c) * \
@@ -179,7 +179,7 @@ def wfs_25d_preeq(omega, omalias, c):
 def delay_3d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     """Plane wave by simple delay of secondary sources."""
     x0 = util.asarray_of_rows(x0)
-    n = util.asarray_1d(n)
+    n = util.normalize_vector(n)
     k = util.wavenumber(omega, c)
     return np.exp(-1j * k * np.inner(n, x0))
 
@@ -191,7 +191,7 @@ def source_selection_plane(n0, n):
 
     """
     n0 = util.asarray_of_rows(n0)
-    n = util.asarray_1d(n)
+    n = util.normalize_vector(n)
     return np.inner(n, n0) >= defs.selection_tolerance
 
 
@@ -225,7 +225,7 @@ def source_selection_focused(ns, x0, xs):
     """
     x0 = util.asarray_of_rows(x0)
     xs = util.asarray_1d(xs)
-    ns = util.asarray_1d(ns)
+    ns = util.normalize_vector(ns)
     ds = xs - x0
     return inner1d(ns, ds) >= defs.selection_tolerance
 
@@ -251,7 +251,7 @@ def nfchoa_2d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
     """
     x0 = util.asarray_of_rows(x0)
     k = util.wavenumber(omega, c)
-    n = util.asarray_1d(n)
+    n = util.normalize_vector(n)
     phi, _, r = util.cart2sph(*n)
     phi0 = util.cart2sph(*x0.T)[0]
     M = _max_order_circular_harmonics(len(x0), max_order)
@@ -305,7 +305,7 @@ def nfchoa_25d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
     """
     x0 = util.asarray_of_rows(x0)
     k = util.wavenumber(omega, c)
-    n = util.asarray_1d(n)
+    n = util.normalize_vector(n)
     phi, _, r = util.cart2sph(*n)
     phi0 = util.cart2sph(*x0.T)[0]
     M = _max_order_circular_harmonics(len(x0), max_order)
@@ -345,7 +345,7 @@ def sdm_2d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     """
     x0 = util.asarray_of_rows(x0)
     n0 = util.asarray_of_rows(n0)
-    n = util.asarray_1d(n)
+    n = util.normalize_vector(n)
     k = util.wavenumber(omega, c)
     return k * n[1] * np.exp(-1j * k * n[0] * x0[:, 0])
 
@@ -361,7 +361,7 @@ def sdm_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
     """
     x0 = util.asarray_of_rows(x0)
     n0 = util.asarray_of_rows(n0)
-    n = util.asarray_1d(n)
+    n = util.normalize_vector(n)
     xref = util.asarray_1d(xref)
     k = util.wavenumber(omega, c)
     return 4j * np.exp(-1j*k*n[1]*xref[1]) / hankel2(0, k*n[1]*xref[1]) * \
@@ -420,6 +420,7 @@ def esa_edge_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None, c=None):
 
     """
     x0 = np.asarray(x0)
+    n = util.normalize_vector(n)
     k = util.wavenumber(omega, c)
     phi_s = np.arctan2(n[1], n[0]) + np.pi
     L = x0.shape[0]
@@ -477,6 +478,7 @@ def esa_edge_dipole_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None, c
 
     """
     x0 = np.asarray(x0)
+    n = util.normalize_vector(n)
     k = util.wavenumber(omega, c)
     phi_s = np.arctan2(n[1], n[0]) + np.pi
     L = x0.shape[0]

--- a/sfs/mono/source.py
+++ b/sfs/mono/source.py
@@ -489,7 +489,7 @@ def plane(omega, x0, n0, grid, c=None):
     """
     k = util.wavenumber(omega, c)
     x0 = util.asarray_1d(x0)
-    n0 = util.asarray_1d(n0)
+    n0 = util.normalize_vector(n0)
     grid = util.as_xyz_components(grid)
     return np.exp(-1j * k * np.inner(grid - x0, n0))
 

--- a/sfs/time/drivingfunction.py
+++ b/sfs/time/drivingfunction.py
@@ -60,7 +60,7 @@ def wfs_25d_plane(x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
         c = defs.c
     x0 = util.asarray_of_rows(x0)
     n0 = util.asarray_of_rows(n0)
-    n = util.asarray_1d(n)
+    n = util.normalize_vector(n)
     xref = util.asarray_1d(xref)
     g0 = np.sqrt(2 * np.pi * np.linalg.norm(xref - x0, axis=1))
     delays = inner1d(n, x0) / c

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -18,8 +18,8 @@ def rotation_matrix(n1, n2):
         Rotation matrix.
 
     """
-    n1 = normal_vector(n1)
-    n2 = normal_vector(n2)
+    n1 = normalize_vector(n1)
+    n2 = normalize_vector(n2)
     I = np.identity(3)
     if np.all(n1 == n2):
         return I  # no rotation
@@ -218,7 +218,7 @@ def broadcast_zip(*args):
     return zip(*np.broadcast_arrays(*args))
 
 
-def normal_vector(x):
+def normalize_vector(x):
     """Normalize a 1D vector."""
     x = asarray_1d(x)
     return x / np.linalg.norm(x)


### PR DESCRIPTION
This tries to fix #20 and #28.

I renamed `util.normal_vector()` to `util.normalize_vector()` as proposed in #28 and used it for every single dimensional direction vector `n`. The field plotted in #20 looks now correct with this.

I'm still not happy with the naming, which I will discuss directly in #28 and there is the problem how to handle several unit vectors at once like `n0 = util.asarray_of_rows(n0)`.