### PR TITLE
Switch to spherical_jn and spherical_yn

### DIFF
--- a/sfs/mono/drivingfunction.py
+++ b/sfs/mono/drivingfunction.py
@@ -6,7 +6,7 @@
 
 import numpy as np
 from numpy.core.umath_tests import inner1d  # element-wise inner product
-from scipy.special import jn, spherical_jn, spherical_yn, hankel2
+from scipy.special import jn, hankel2
 from .. import util
 from .. import defs
 
@@ -281,8 +281,8 @@ def nfchoa_25d_point(omega, x0, r0, xs, max_order=None, c=None):
     phi, _, r = util.cart2sph(*xs)
     phi0 = util.cart2sph(*x0.T)[0]
     M = _max_order_circular_harmonics(len(x0), max_order)
-    hr = _spherical_hn2(range(0, M + 1), k * r)
-    hr0 = _spherical_hn2(range(0, M + 1), k * r0)
+    hr = util.spherical_hn2(range(0, M + 1), k * r)
+    hr0 = util.spherical_hn2(range(0, M + 1), k * r0)
     d = 0
     for m in range(-M, M + 1):
         d += hr[abs(m)] / hr0[abs(m)] * np.exp(1j * m * (phi0 - phi))
@@ -310,7 +310,7 @@ def nfchoa_25d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
     phi0 = util.cart2sph(*x0.T)[0]
     M = _max_order_circular_harmonics(len(x0), max_order)
     d = 0
-    hn2 = _spherical_hn2(range(0, M + 1), k * r0)
+    hn2 = util.spherical_hn2(range(0, M + 1), k * r0)
     for m in range(-M, M + 1):
         d += 1j**-abs(m) / (k * hn2[abs(m)]) * np.exp(1j * m * (phi0 - phi))
     return -2 / r0 * d
@@ -667,29 +667,6 @@ def esa_edge_dipole_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
         d[~idx] = d[~idx] + f[~idx] * jn(nu, k*r_s) * hankel2(nu, k*r[~idx])
 
     return -1j*np.pi/alpha * d
-
-
-def _spherical_hn2(n, z):
-    r"""Spherical Hankel function of 2nd kind.
-
-    Defined as http://dlmf.nist.gov/10.47.E6,
-
-    .. math:: \hankel{2}{n}{z} = \sqrt{\frac{\pi}{2z}} \Hankel{2}{n + 1/2}{z},
-
-    where :math:`\Hankel{2}{n}{}` is the Hankel function of the second kind.
-
-    Parameters
-    ----------
-    n : int, array_like
-        Order of the spherical Hankel function (n >= 0).
-    z : complex or float, array_like
-        Argument of the spherical Hankel function.
-
-    Returns
-    -------
-    hn2 : ndarray
-    """
-    return spherical_jn(n, z) - 1j * spherical_yn(n, z)
 
 
 def _max_order_circular_harmonics(N, max_order):

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -3,6 +3,7 @@
 from __future__ import division
 import collections
 import numpy as np
+from scipy.special import spherical_jn, spherical_yn
 from . import defs
 
 
@@ -491,3 +492,27 @@ def image_sources_for_box(x, L, N, prune=True):
         wall_count = wall_count[N_mask, :]
 
     return xs, wall_count
+
+
+def spherical_hn2(n, z):
+    r"""Spherical Hankel function of 2nd kind.
+
+    Defined as http://dlmf.nist.gov/10.47.E6,
+
+    .. math::
+
+        \hankel{2}{n}{z} = \sqrt{\frac{\pi}{2z}}
+        \Hankel{2}{n + \frac{1}{2}}{z},
+
+    where :math:`\Hankel{2}{n}{\cdot}` is the Hankel function of the
+    second kind and n-th order, and :math:`z` its complex argument.
+
+    Parameters
+    ----------
+    n : array_like
+        Order of the spherical Hankel function (n >= 0).
+    z : array_like
+        Argument of the spherical Hankel function.
+
+    """
+    return spherical_jn(n, z) - 1j * spherical_yn(n, z)

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -1,4 +1,8 @@
-"""Various utility functions."""
+"""Various utility functions.
+
+.. include:: math-definitions.rst
+
+"""
 
 from __future__ import division
 import collections


### PR DESCRIPTION
This tries to fix #43.

Unfortunately, the return values of the spherical Bessel functions seem to have changed as well, even if the documentation still states `ndarray`.
If you execute the following code with my changes you will get an error:
```python
import numpy as np
import sfs
nk = 0, -1, 0  # direction of plane wave
omega = 2 * np.pi * 1000  # frequency
R0 = 1.5  # radius of secondary sources
x0, n0, a0 = sfs.array.circular(200, R0)
grid = sfs.util.xyz_grid([-1.75, 1.75], [-1.75, 1.75], 0, spacing=0.02)
d = sfs.mono.drivingfunction.nfchoa_25d_plane(omega, x0, R0, nk)
```
The error is
```
IndexError                                Traceback (most recent call last)
<ipython-input-5-5d956e53e92e> in <module>()
----> 1 d = sfs.mono.drivingfunction.nfchoa_25d_plane(omega, x0, R0, nk)

/scratch/git/sfs-python/sfs/mono/drivingfunction.py in nfchoa_25d_plane(omega, x0, r0, n, max_order, c)
    313     d = 0
    314     for m in range(-M, M + 1):
--> 315         d += 1j**-abs(m) / (k * hn2[abs(m)]) * np.exp(1j * m * (phi0 - phi))
    316     return -2 / r0 * d
    317 

IndexError: invalid index to scalar variable.
```