### PR TITLE
Handling of references

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,7 @@
     time-domain
     plotting
     utilities
+    references
     contributing
     version-history
 

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -1,0 +1,16 @@
+References
+==========
+
+.. [Ahrens2012] Ahrens, J., *Analytic Methods of Sound Field Synthesis*. (Springer, Berlin Heidelberg, 2012), doi:`10.1007/978-3-642-25743-8 <https://doi.org/10.1007/978-3-642-25743-8>`__
+
+.. [Moser2012] Möser, M., *Technische Akustik*. (Springer, Berlin Heidelberg, 2012), doi:`10.1007/978-3-642-30933-5 <https://doi.org/10.1007/978-3-642-30933-5>`__
+
+.. [SporsAhrens2010] Spors, S., Ahrens, J., “Analysis and Improvement of Pre-equalization in 2.5-dimensional Wave Field Synthesis,” in *128th Conv. Audio Eng. Soc.*, London, UK (2010), Paper 8121, `pdf <https://www.int.uni-rostock.de/fileadmin/user_upload/publications/spors/2010/AES128_Spors_etal_WFS_preeq.pdf>`__
+
+.. [SporsAhrens2009] Spors, S., Ahrens, J., “Spatial Sampling Artifacts of Wave Field Synthesis for the Reproduction of Virtual Point Sources,” in *126th Conv. Audio Eng. Soc.*, Munich, Germany (2009), Paper 7744, `pdf <https://www.int.uni-rostock.de/fileadmin/user_upload/publications/spors/2009/AES126_Spors_etal_WFS_spatial_aliasing.pdf>`__
+
+.. [Spors2016] Spors, S., Schultz, F., Rettberg, T., “Improved Driving Functions for Rectangular Loudspeaker Arrays Driven by Sound Field Synthesis,” in *42nd Ger. Ann. Conf. Acoust. (DAGA)*, Aachen, Germany (2016), `pdf <https://www.int.uni-rostock.de/fileadmin/user_upload/publications/spors/2016/Spors_etal_DAGA_SFS_rect_array.pdf>`__
+
+.. [Spors2008] Spors, S., Rabenstein, R., and Ahrens, J., “The Theory of Wave Field Synthesis Revisited,” in *124th Conv. Audio Eng. Soc.*, Amsterdam, Netherlands (2008), preprint 7358, `pdf <https://www.int.uni-rostock.de/fileadmin/user_upload/publications/spors/2008/AES124_Spors_WFS_Theory.pdf>`__
+
+.. [Wierstorf2014] Wierstorf, H., *Perceptual Assessment of Sound Field Synthesis*, Ph.D. dissertation, Technische Universität Berlin, Berlin, Germany, 2014, doi:`10.14279/depositonce-4310 <http://dx.doi.org/10.14279/depositonce-4310>`__

--- a/sfs/mono/drivingfunction.py
+++ b/sfs/mono/drivingfunction.py
@@ -79,7 +79,7 @@ wfs_3d_point = _wfs_point
 def _wfs_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     """Plane wave by two- or three-dimensional WFS.
 
-    Eq.(17) from [Spors et al, 2008]::
+    Eq.(17) from [Spors2008]_::
 
         D(x0,k) =  j k n n0  e^(-j k n x0)
 
@@ -187,7 +187,7 @@ def delay_3d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
 def source_selection_plane(n0, n):
     """Secondary source selection for a plane wave.
 
-    Eq.(13) from [Spors et al, 2008]
+    Eq.(13) from [Spors2008]_
 
     """
     n0 = util.asarray_of_rows(n0)
@@ -198,7 +198,7 @@ def source_selection_plane(n0, n):
 def source_selection_point(n0, x0, xs):
     """Secondary source selection for a point source.
 
-    Eq.(15) from [Spors et al, 2008]
+    Eq.(15) from [Spors2008]_
 
     """
     n0 = util.asarray_of_rows(n0)
@@ -211,7 +211,7 @@ def source_selection_point(n0, x0, xs):
 def source_selection_line(n0, x0, xs):
     """Secondary source selection for a line source.
 
-    compare Eq.(15) from [Spors et al, 2008]
+    compare Eq.(15) from [Spors2008]_
 
     """
     return source_selection_point(n0, x0, xs)
@@ -220,7 +220,7 @@ def source_selection_line(n0, x0, xs):
 def source_selection_focused(ns, x0, xs):
     """Secondary source selection for a focused source.
 
-    Eq.(2.78) from [Wierstorf, 2014]
+    Eq.(2.78) from [Wierstorf2014]_
 
     """
     x0 = util.asarray_of_rows(x0)
@@ -320,7 +320,7 @@ def sdm_2d_line(omega, x0, n0, xs, c=None):
     """Line source by two-dimensional SDM.
 
     The secondary sources have to be located on the x-axis (y0=0).
-    Derived from [Spors 2009, 126th AES Convention], Eq.(9), Eq.(4)::
+    Derived from [SporsAhrens2009]_, Eq.(9), Eq.(4)::
 
         D(x0,k) =
 
@@ -338,7 +338,7 @@ def sdm_2d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     """Plane wave by two-dimensional SDM.
 
     The secondary sources have to be located on the x-axis (y0=0).
-    Derived from [Ahrens 2011, Springer], Eq.(3.73), Eq.(C.5), Eq.(C.11)::
+    Derived from [Ahrens2012]_, Eq.(3.73), Eq.(C.5), Eq.(C.11)::
 
         D(x0,k) = kpw,y * e^(-j*kpw,x*x)
 
@@ -354,7 +354,7 @@ def sdm_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
     """Plane wave by 2.5-dimensional SDM.
 
     The secondary sources have to be located on the x-axis (y0=0).
-    Eq.(3.79) from [Ahrens 2011, Springer]::
+    Eq.(3.79) from [Ahrens2012]_::
 
         D_2.5D(x0,w) =
 
@@ -372,7 +372,7 @@ def sdm_25d_point(omega, x0, n0, xs, xref=[0, 0, 0], c=None):
     """Point source by 2.5-dimensional SDM.
 
     The secondary sources have to be located on the x-axis (y0=0).
-    Driving funcnction from [Spors 2010, 128th AES Covention], Eq.(24)::
+    Driving funcnction from [SporsAhrens2010]_, Eq.(24)::
 
         D(x0,k) =
 
@@ -395,7 +395,7 @@ def esa_edge_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None, c=None):
     One leg of the secondary sources has to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors 2016, DAGA]
+    Derived from [Spors2016]_
 
     Parameters
     ----------
@@ -453,7 +453,7 @@ def esa_edge_dipole_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None, c
     One leg of the secondary sources has to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors 2016, DAGA]
+    Derived from [Spors2016]_
 
     Parameters
     ----------
@@ -509,7 +509,7 @@ def esa_edge_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     One leg of the secondary sources have to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors 2016, DAGA]
+    Derived from [Spors2016]_
 
     Parameters
     ----------
@@ -571,7 +571,7 @@ def esa_edge_25d_point(omega, x0, xs, xref=[2, -2, 0], alpha=3/2*np.pi, Nc=None,
     One leg of the secondary sources have to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors 2016, DAGA]
+    Derived from [Spors2016]_
 
     Parameters
     ----------
@@ -616,7 +616,7 @@ def esa_edge_dipole_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     One leg of the secondary sources have to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors 2016, DAGA]
+    Derived from [Spors2016]_
 
     Parameters
     ----------

--- a/sfs/mono/source.py
+++ b/sfs/mono/source.py
@@ -449,7 +449,7 @@ def line_dipole(omega, x0, n0, grid, c=None):
 def line_dirichlet_edge(omega, x0, grid, alpha=3/2*np.pi, Nc=None, c=None):
     """Line source scattered at an edge with Dirichlet boundary conditions.
 
-    [Michael M"oser, Technische Akustik, 2012, Springer, eq.(10.18/19)]
+    [Moser2012]_, eq.(10.18/19)
 
     Parameters
     ----------


### PR DESCRIPTION
At the moment we handle citations of references a little bit sloppy. They are usually in the form of `[Spors et al, 2008]` without explaining which exact paper this is.

I see two solutions to this:
1.) As implemented in this pull request: stay with the short citations in the help messages, but make them click able and add a reference page in the online documentation. The above statement would then be `[Spors2008]_` in the help text of the function.

2.) Another solution would be to add the name of the actual publication to the help text as done in #45 at the moment.