### PR TITLE
Generalization of the modal order argument

### DIFF
--- a/sfs/mono/source.py
+++ b/sfs/mono/source.py
@@ -169,10 +169,9 @@ def point_modal(omega, x0, n0, grid, L, N=None, deltan=0, c=None):
     L : (3,) array_like
         Dimensionons of the rectangular room.
     N : (3,) array_like or int, optional
-        Modal orders in the three-spatial dimensions to calculate the sound
-        field for or maximum orders. If not given, the maximum modal order is
-        approximately determined and the sound field is computed up to this
-        maximum order. Scalars apply to all three dimensions.
+        For all three spatial dimensions per dimension maximum order,
+        list of orders used or if not given maximum modal order is
+        approximately determined. A scalar applies to all three dimensions.
     deltan : float, optional
         Absorption coefficient of the walls.
     c : float, optional
@@ -189,7 +188,7 @@ def point_modal(omega, x0, n0, grid, L, N=None, deltan=0, c=None):
     x, y, z = util.as_xyz_components(grid)
 
     if np.isscalar(N):
-        N = N * np.ones(3)
+        N = N * np.ones(3, dtype=int)
 
     if N is None:
             N = [None, None, None]
@@ -198,10 +197,10 @@ def point_modal(omega, x0, n0, grid, L, N=None, deltan=0, c=None):
     for i in range(3):
         if N[i] is None:
             # compute max order
-            orders[i] = range(int(np.ceil(L[i]/np.pi * k) + 1))
+            orders[i] = range(np.ceil(L[i]/np.pi * k) + 1)
         elif np.isscalar(N[i]):
             # use given max order
-            orders[i] = range(int(N[i]+1))
+            orders[i] = range(N[i] + 1)
         else:
             # use given orders
             orders[i] = N[i]

--- a/sfs/mono/source.py
+++ b/sfs/mono/source.py
@@ -169,9 +169,9 @@ def point_modal(omega, x0, n0, grid, L, N=None, deltan=0, c=None):
     L : (3,) array_like
         Dimensionons of the rectangular room.
     N : (3,) array_like or int, optional
-        For all three spatial dimensions per dimension maximum order,
-        list of orders used or if not given maximum modal order is
-        approximately determined. A scalar applies to all three dimensions.
+        For all three spatial dimensions per dimension maximum order or
+        ￼list of orders. A scalar applies to all three dimensions. If no
+        order is provided it is approximately determined.
     deltan : float, optional
         Absorption coefficient of the walls.
     c : float, optional
@@ -197,7 +197,7 @@ def point_modal(omega, x0, n0, grid, L, N=None, deltan=0, c=None):
     for i in range(3):
         if N[i] is None:
             # compute max order
-            orders[i] = range(np.ceil(L[i]/np.pi * k) + 1)
+            orders[i] = range(int(np.ceil(L[i]/np.pi * k) + 1))
         elif np.isscalar(N[i]):
             # use given max order
             orders[i] = range(N[i] + 1)

--- a/sfs/mono/source.py
+++ b/sfs/mono/source.py
@@ -169,11 +169,10 @@ def point_modal(omega, x0, n0, grid, L, N=None, deltan=0, c=None):
     L : (3,) array_like
         Dimensionons of the rectangular room.
     N : (3,) array_like or int, optional
-        Combination of modal orders in the three-spatial dimensions to
-        calculate the sound field for or maximum order for all
-        dimensions.  If not given, the maximum modal order is
-        approximately determined and the sound field is computed up to
-        this maximum order.
+        Modal orders in the three-spatial dimensions to calculate the sound
+        field for or maximum orders. If not given, the maximum modal order is
+        approximately determined and the sound field is computed up to this
+        maximum order. Scalars apply to all three dimensions.
     deltan : float, optional
         Absorption coefficient of the walls.
     c : float, optional
@@ -189,31 +188,30 @@ def point_modal(omega, x0, n0, grid, L, N=None, deltan=0, c=None):
     x0 = util.asarray_1d(x0)
     x, y, z = util.as_xyz_components(grid)
 
+    if np.isscalar(N):
+        N = N * np.ones(3)
+
     if N is None:
-        # determine maximum modal order per dimension
-        Nx = int(np.ceil(L[0]/np.pi * k))
-        Ny = int(np.ceil(L[1]/np.pi * k))
-        Nz = int(np.ceil(L[2]/np.pi * k))
-        mm = range(Nx)
-        nn = range(Ny)
-        ll = range(Nz)
-    elif np.isscalar(N):
-        # compute up to a given order
-        mm = range(N)
-        nn = range(N)
-        ll = range(N)
-    else:
-        # compute field for one order combination only
-        mm = [N[0]]
-        nn = [N[1]]
-        ll = [N[2]]
+            N = [None, None, None]
+
+    orders = [0, 0, 0]
+    for i in range(3):
+        if N[i] is None:
+            # compute max order
+            orders[i] = range(int(np.ceil(L[i]/np.pi * k) + 1))
+        elif np.isscalar(N[i]):
+            # use given max order
+            orders[i] = range(int(N[i]+1))
+        else:
+            # use given orders
+            orders[i] = N[i]
 
     kmp0 = [((kx + 1j * deltan)**2, np.cos(kx * x) * np.cos(kx * x0[0]))
-            for kx in [m * np.pi / L[0] for m in mm]]
+            for kx in [m * np.pi / L[0] for m in orders[0]]]
     kmp1 = [((ky + 1j * deltan)**2, np.cos(ky * y) * np.cos(ky * x0[1]))
-            for ky in [n * np.pi / L[1] for n in nn]]
+            for ky in [n * np.pi / L[1] for n in orders[1]]]
     kmp2 = [((kz + 1j * deltan)**2, np.cos(kz * z) * np.cos(kz * x0[2]))
-            for kz in [l * np.pi / L[2] for l in ll]]
+            for kz in [l * np.pi / L[2] for l in orders[2]]]
     ksquared = k**2
     p = 0
     for (km0, p0), (km1, p1), (km2, p2) in itertools.product(kmp0, kmp1, kmp2):


### PR DESCRIPTION
The argument `N` can now handle scalars or a vector containing for all three dimensions `None` for computation of max order, a scalar for a given maximum order or a vector for given orders per dimension. For instance

- `N=10 or N = [10, 10, 10]` computes the field in all three dimensions up to order 10
- `N = [None, None, [0]]` calculates the order in the first two dimensions and uses zeroth-order for the third dimension