### PR TITLE
Use sphinxcontrib-bibtex for references

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'sphinx.ext.napoleon',  # support for NumPy-style docstrings
     'sphinx.ext.intersphinx',
     'sphinx.ext.extlinks',
+    'sphinxcontrib.bibtex',
     'matplotlib.sphinxext.plot_directive',
     'nbsphinx',
 ]

--- a/doc/readthedocs-environment.yml
+++ b/doc/readthedocs-environment.yml
@@ -4,6 +4,7 @@ dependencies:
   - python==3.5
   - sphinx>=1.3.6
   - sphinx_rtd_theme
+  - sphinxcontrib-bibtex
   - numpy
   - scipy
   - matplotlib>=1.5

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,0 +1,72 @@
+@book{Ahrens2012,
+    author = {Ahrens, J.},
+    title = {{Analytic Methods of Sound Field Synthesis}},
+    publisher = {Springer},
+    address = {Berlin Heidelberg},
+    year = {2012},
+    doi = {10.1007/978-3-642-25743-8}
+}
+@book{Moser2012,
+    author = {M\"{o}ser, M.},
+    title = {{Technische Akustik}},
+    publisher = {Springer},
+    address = {Berlin Heidelberg},
+    year = {2012},
+    doi = {10.1007/978-3-642-30933-5}
+}
+@inproceedings{Spors2010,
+    author = {Spors, S. and Ahrens, J.},
+    title = {{Analysis and Improvement of Pre-equalization in 2.5-dimensional
+        Wave Field Synthesis}},
+    booktitle = {128th Convention of the Audio Engineering Society},
+    year = {2010},
+    url = {http://bit.ly/2Ad6RRR}
+}
+@inproceedings{Spors2009,
+    author = {Spors, S. and Ahrens, J.},
+    title = {{Spatial Sampling Artifacts of Wave Field Synthesis for the
+        Reproduction of Virtual Point Sources}},
+    booktitle = {126th Convention of the Audio Engineering Society},
+    year = {2009},
+    url = {http://bit.ly/2jkfboi}
+}
+@inproceedings{Spors2016,
+    author = {Spors, S. and Schultz, F. and Rettberg, T.},
+    title = {{Improved Driving Functions for Rectangular Loudspeaker Arrays
+        Driven by Sound Field Synthesis}},
+    booktitle = {42nd German Annual Conference on Acoustics (DAGA)},
+    year = {2016},
+    url = {http://bit.ly/2AWRo7G}
+}
+@inproceedings{Spors2008,
+    author = {Spors, S. and Rabenstein, R. and Ahrens, J.},
+    title = {{The Theory of Wave Field Synthesis Revisited}},
+    booktitle = {124th Convention of the Audio Engineering Society},
+    year = {2008},
+    url = {http://bit.ly/2ByRjnB}
+}
+@phdthesis{Wierstorf2014,
+    author = {Wierstorf, H.},
+    title = {{Perceptual Assessment of Sound Field Synthesis}},
+    school = {Technische Universität Berlin},
+    year = {2014},
+    doi = {10.14279/depositonce-4310}
+}
+@article{Allen1979,
+    author = {Allen, J. B. and  Berkley, D. A.},
+    title = {{Image method for efficiently simulating small‐room acoustics}},
+    journal = {Journal of the Acoustical Society of America},
+    volume = {65},
+    pages = {943--950},
+    year = {1979},
+    doi = {10.1121/1.382599}
+}
+@article{Borish1984,
+    author = {Borish, J.},
+    title = {{Extension of the image model to arbitrary polyhedra}},
+    journal = {Journal of the Acoustical Society of America},
+    volume = {75},
+    pages = {1827--1836},
+    year = {1984},
+    doi = {10.1121/1.390983}
+}

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -7,7 +7,7 @@
     doi = {10.1007/978-3-642-25743-8}
 }
 @book{Moser2012,
-    author = {M\"{o}ser, M.},
+    author = {Möser, M.},
     title = {{Technische Akustik}},
     publisher = {Springer},
     address = {Berlin Heidelberg},

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -1,56 +1,6 @@
 References
 ==========
 
-.. [Ahrens2012]
-    Ahrens, J.,
-    *Analytic Methods of Sound Field Synthesis*.
-    (Springer, Berlin Heidelberg, 2012),
-    doi:`10.1007/978-3-642-25743-8 <https://doi.org/10.1007/978-3-642-25743-8>`__
-
-.. [Moser2012]
-    Möser, M.,
-    *Technische Akustik*.
-    (Springer, Berlin Heidelberg, 2012),
-    doi:`10.1007/978-3-642-30933-5 <https://doi.org/10.1007/978-3-642-30933-5>`__
-
-.. [SporsAhrens2010]
-    Spors, S., Ahrens, J.,
-    “Analysis and Improvement of Pre-equalization in 2.5-dimensional Wave Field Synthesis,”
-    in *128th Conv. Audio Eng. Soc.*, London, UK (2010), Paper 8121,
-    `pdf <https://www.int.uni-rostock.de/fileadmin/user_upload/publications/spors/2010/AES128_Spors_etal_WFS_preeq.pdf>`__
-
-.. [SporsAhrens2009]
-    Spors, S., Ahrens, J.,
-    “Spatial Sampling Artifacts of Wave Field Synthesis for the Reproduction of Virtual Point Sources,”
-    in *126th Conv. Audio Eng. Soc.*, Munich, Germany (2009), Paper 7744,
-    `pdf <https://www.int.uni-rostock.de/fileadmin/user_upload/publications/spors/2009/AES126_Spors_etal_WFS_spatial_aliasing.pdf>`__
-
-.. [Spors2016]
-    Spors, S., Schultz, F., Rettberg, T.,
-    “Improved Driving Functions for Rectangular Loudspeaker Arrays Driven by Sound Field Synthesis,”
-    in *42nd Ger. Ann. Conf. Acoust. (DAGA)*, Aachen, Germany (2016),
-    `pdf <https://www.int.uni-rostock.de/fileadmin/user_upload/publications/spors/2016/Spors_etal_DAGA_SFS_rect_array.pdf>`__
-
-.. [Spors2008]
-    Spors, S., Rabenstein, R., and Ahrens, J.,
-    “The Theory of Wave Field Synthesis Revisited,”
-    in *124th Conv. Audio Eng. Soc.*, Amsterdam, Netherlands (2008), Paper 7358,
-    `pdf <https://www.int.uni-rostock.de/fileadmin/user_upload/publications/spors/2008/AES124_Spors_WFS_Theory.pdf>`__
-
-.. [Wierstorf2014]
-    Wierstorf, H.,
-    *Perceptual Assessment of Sound Field Synthesis*,
-    Ph.D. dissertation, Technische Universität Berlin, Berlin, Germany, 2014,
-    doi:`10.14279/depositonce-4310 <http://dx.doi.org/10.14279/depositonce-4310>`__
-
-.. [AllenBerkley1979]
-    Allen, J. B., Berkley, D. A.,
-    “Image method for efficiently simulating small‐room acoustics,”
-    J. Acoust. Soc. Am. **65**, 943-950 (1979),
-    doi:`10.1121/1.382599 <https://doi.org/10.1121/1.382599>`__
-
-.. [Borish1984]
-    Borish, J.,
-    “Extension of the image model to arbitrary polyhedra,”
-    J. Acoust. Soc. Am. **75**, 1827-1836 (1984),
-    doi:`10.1121/1.390983 <https://doi.org/10.1121/1.390983>`__
+.. bibliography:: references.bib
+    :style: alpha
+    :all:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,6 +2,7 @@ Sphinx>=1.3.6
 Sphinx-RTD-Theme
 nbsphinx
 ipykernel
+sphinxcontrib-bibtex
 
 NumPy
 SciPy

--- a/sfs/mono/drivingfunction.py
+++ b/sfs/mono/drivingfunction.py
@@ -79,7 +79,7 @@ wfs_3d_point = _wfs_point
 def _wfs_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     """Plane wave by two- or three-dimensional WFS.
 
-    Eq.(17) from [Spors2008]_::
+    Eq.(17) from :cite:`Spors2008`::
 
         D(x0,k) =  j k n n0  e^(-j k n x0)
 
@@ -187,7 +187,7 @@ def delay_3d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
 def source_selection_plane(n0, n):
     """Secondary source selection for a plane wave.
 
-    Eq.(13) from [Spors2008]_
+    Eq.(13) from :cite:`Spors2008`
 
     """
     n0 = util.asarray_of_rows(n0)
@@ -198,7 +198,7 @@ def source_selection_plane(n0, n):
 def source_selection_point(n0, x0, xs):
     """Secondary source selection for a point source.
 
-    Eq.(15) from [Spors2008]_
+    Eq.(15) from :cite:`Spors2008`
 
     """
     n0 = util.asarray_of_rows(n0)
@@ -211,7 +211,7 @@ def source_selection_point(n0, x0, xs):
 def source_selection_line(n0, x0, xs):
     """Secondary source selection for a line source.
 
-    compare Eq.(15) from [Spors2008]_
+    compare Eq.(15) from :cite:`Spors2008`
 
     """
     return source_selection_point(n0, x0, xs)
@@ -220,7 +220,7 @@ def source_selection_line(n0, x0, xs):
 def source_selection_focused(ns, x0, xs):
     """Secondary source selection for a focused source.
 
-    Eq.(2.78) from [Wierstorf2014]_
+    Eq.(2.78) from :cite:`Wierstorf2014`
 
     """
     x0 = util.asarray_of_rows(x0)
@@ -320,7 +320,7 @@ def sdm_2d_line(omega, x0, n0, xs, c=None):
     """Line source by two-dimensional SDM.
 
     The secondary sources have to be located on the x-axis (y0=0).
-    Derived from [SporsAhrens2009]_, Eq.(9), Eq.(4)::
+    Derived from :cite:`Spors2009`, Eq.(9), Eq.(4)::
 
         D(x0,k) =
 
@@ -338,7 +338,7 @@ def sdm_2d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     """Plane wave by two-dimensional SDM.
 
     The secondary sources have to be located on the x-axis (y0=0).
-    Derived from [Ahrens2012]_, Eq.(3.73), Eq.(C.5), Eq.(C.11)::
+    Derived from :cite:`Ahrens2012`, Eq.(3.73), Eq.(C.5), Eq.(C.11)::
 
         D(x0,k) = kpw,y * e^(-j*kpw,x*x)
 
@@ -354,7 +354,7 @@ def sdm_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
     """Plane wave by 2.5-dimensional SDM.
 
     The secondary sources have to be located on the x-axis (y0=0).
-    Eq.(3.79) from [Ahrens2012]_::
+    Eq.(3.79) from :cite:`Ahrens2012`::
 
         D_2.5D(x0,w) =
 
@@ -372,7 +372,7 @@ def sdm_25d_point(omega, x0, n0, xs, xref=[0, 0, 0], c=None):
     """Point source by 2.5-dimensional SDM.
 
     The secondary sources have to be located on the x-axis (y0=0).
-    Driving funcnction from [SporsAhrens2010]_, Eq.(24)::
+    Driving funcnction from :cite:`Spors2010`, Eq.(24)::
 
         D(x0,k) =
 
@@ -395,7 +395,7 @@ def esa_edge_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None, c=None):
     One leg of the secondary sources has to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors2016]_
+    Derived from :cite:`Spors2016`
 
     Parameters
     ----------
@@ -453,7 +453,7 @@ def esa_edge_dipole_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None, c
     One leg of the secondary sources has to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors2016]_
+    Derived from :cite:`Spors2016`
 
     Parameters
     ----------
@@ -509,7 +509,7 @@ def esa_edge_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     One leg of the secondary sources have to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors2016]_
+    Derived from :cite:`Spors2016`
 
     Parameters
     ----------
@@ -571,7 +571,7 @@ def esa_edge_25d_point(omega, x0, xs, xref=[2, -2, 0], alpha=3/2*np.pi, Nc=None,
     One leg of the secondary sources have to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors2016]_
+    Derived from :cite:`Spors2016`
 
     Parameters
     ----------
@@ -616,7 +616,7 @@ def esa_edge_dipole_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     One leg of the secondary sources have to be located on the x-axis (y0=0),
     the edge at the origin.
 
-    Derived from [Spors2016]_
+    Derived from :cite:`Spors2016`
 
     Parameters
     ----------

--- a/sfs/mono/source.py
+++ b/sfs/mono/source.py
@@ -446,7 +446,7 @@ def line_dipole(omega, x0, n0, grid, c=None):
 def line_dirichlet_edge(omega, x0, grid, alpha=3/2*np.pi, Nc=None, c=None):
     """Line source scattered at an edge with Dirichlet boundary conditions.
 
-    [Moser2012]_, eq.(10.18/19)
+    :cite:`Moser2012`, eq.(10.18/19)
 
     Parameters
     ----------

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -426,7 +426,7 @@ If you want to ensure that a given variable contains a valid signal, use
 def image_sources_for_box(x, L, N, prune=True):
     """Image source method for a cuboid room.
 
-    The classical method by [AllenBerkley1979]_.
+    The classical method by :cite:`Allen1979`.
 
     Parameters
     ----------
@@ -448,7 +448,7 @@ def image_sources_for_box(x, L, N, prune=True):
           Returns reflected up to N times between individual wall pairs,
           a total number of :math:`M := (2N+1)^D`.
           This larger set is useful e.g. to select image sources based on
-          distance to listener, as suggested by [Borish1984]_.
+          distance to listener, as suggested by :cite:`Borish1984`.
 
 
     Returns

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -426,7 +426,7 @@ If you want to ensure that a given variable contains a valid signal, use
 def image_sources_for_box(x, L, N, prune=True):
     """Image source method for a cuboid room.
 
-    The classical method by :cite:`Allen1979`.
+    The classical method by Allen and Berkley :cite:`Allen1979`.
 
     Parameters
     ----------


### PR DESCRIPTION
As proposed in #49 I switched to [sphinxcontrib-bibtex](https://github.com/mcmtroffaes/sphinxcontrib-bibtex/) for references.

Using the `unsrt` style this creates a numbered ([1], [2], ...) list of references, see http://python.sfstoolbox.org/en/bibtex/references.html.

This means inside the text we have now also only numbered links like "Eq.(17) from [[7]](http://python.sfstoolbox.org/en/bibtex/references.html#spors2008)", see [wfs_2d_plane](http://python.sfstoolbox.org/en/bibtex/frequency-domain.html#sfs.mono.drivingfunction.wfs_2d_plane). In most of the times this should be fine, I only changed it for the first entry in the [docstring of image_sources_for_box](http://python.sfstoolbox.org/en/bibtex/utilities.html#sfs.util.image_sources_for_box).

In a third commit I also started to clean up the links provided in the reference by replacing links to PDF versions of AES papers with the official permalinks. This is only optional and don't have to be included, but I thought it looks cleaner that way. The disadvantage is of course, that if you are not an AES member you have to google for the PDF.