### PR TITLE
Update to new sfstoolbox.org/en/3.0 permalinks

### DIFF
--- a/sfs/mono/drivingfunction.py
+++ b/sfs/mono/drivingfunction.py
@@ -246,7 +246,7 @@ def nfchoa_2d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
         \frac{\i^{-m}}{\Hankel{2}{m}{\wc r_0}}
         \e{\i m (\phi_0 - \phi_\text{pw})}
 
-    See http://sfstoolbox.org/#equation-D.nfchoa.pw.2D.
+    See http://sfstoolbox.org/en/3.0/d_nfchoa/#equation-D.nfchoa.pw.2D.
 
     """
     x0 = util.asarray_of_rows(x0)
@@ -272,7 +272,7 @@ def nfchoa_25d_point(omega, x0, r0, xs, max_order=None, c=None):
         \frac{\hankel{2}{|m|}{\wc r}}{\hankel{2}{|m|}{\wc r_0}}
         \e{\i m (\phi_0 - \phi)}
 
-    See http://sfstoolbox.org/#equation-D.nfchoa.ps.2.5D.
+    See http://sfstoolbox.org/en/3.0/d_nfchoa/#equation-D.nfchoa.ps.2.5D.
 
     """
     x0 = util.asarray_of_rows(x0)
@@ -300,7 +300,7 @@ def nfchoa_25d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
         \frac{\i^{-|m|}}{\wc \hankel{2}{|m|}{\wc r_0}}
         \e{\i m (\phi_0 - \phi_\text{pw})}
 
-    See http://sfstoolbox.org/#equation-D.nfchoa.pw.2.5D.
+    See http://sfstoolbox.org/en/3.0/d_nfchoa/#equation-D.nfchoa.pw.2.5D.
 
     """
     x0 = util.asarray_of_rows(x0)

--- a/sfs/time/drivingfunction.py
+++ b/sfs/time/drivingfunction.py
@@ -53,7 +53,7 @@ def wfs_25d_plane(x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
 
     References
     ----------
-    See http://sfstoolbox.org/en/latest/#equation-d.wfs.pw.2.5D
+    See http://sfstoolbox.org/en/3.0/d_wfs/#equation-d.wfs.pw.2.5D.
 
     """
     if c is None:
@@ -113,7 +113,7 @@ def wfs_25d_point(x0, n0, xs, xref=[0, 0, 0], c=None):
 
     References
     ----------
-    See http://sfstoolbox.org/en/latest/#equation-d.wfs.ps.2.5D
+    See http://sfstoolbox.org/en/3.0/d_wfs/#equation-d.wfs.ps.2.5D.
 
     """
     if c is None:
@@ -176,7 +176,7 @@ def wfs_25d_focused(x0, n0, xs, xref=[0, 0, 0], c=None):
 
     References
     ----------
-    See http://sfstoolbox.org/en/latest/#equation-d.wfs.fs.2.5D
+    See http://sfstoolbox.org/en/3.0/d_wfs/#equation-d.wfs.fs.2.5D.
 
     """
     if c is None:


### PR DESCRIPTION
This upgrades all the permalinks to equations on http://sfstoolbox.org to the new http://sfstoolbox.org/en/3.0 version.