### PR TITLE
DOC: add link to theory, matlab, and python to sidebar

### DIFF
--- a/doc/_static/css/title.css
+++ b/doc/_static/css/title.css
@@ -1,0 +1,33 @@
+.wy-side-nav-search>a, .wy-side-nav-search .wy-dropdown>a {
+    font-family: "Roboto Slab","ff-tisa-web-pro","Georgia",Arial,sans-serif;
+    font-size: 200%;
+    margin-top: .222em;
+    margin-bottom: .202em;
+}
+.wy-side-nav-search {
+    padding: 0;
+}
+form#rtd-search-form {
+    margin-left: .809em;
+    margin-right: .809em;
+}
+.rtd-nav a {
+    float: left;
+    display: block;
+    width: 33.3%;
+    height: 100%;
+    padding-top: 7px;
+    color: white;
+}
+.rtd-nav {
+    overflow: hidden;
+    width: 100%;
+    height: 35px;
+    margin-top: 15px;
+}
+.rtd-nav a:hover {
+    background-color: #388bbd;
+}
+.rtd-nav a.active {
+    background-color: #388bbd;
+}

--- a/doc/_template/layout.html
+++ b/doc/_template/layout.html
@@ -1,0 +1,14 @@
+{% extends "!layout.html" %}
+{% block sidebartitle %}
+
+  <a href="{{ pathto(master_doc) }}"> {{ project }}</a>
+
+  {% include "searchbox.html" %}
+
+	<div class="rtd-nav">
+		<a href="http://sfstoolbox.org/">Theory</a>
+		<a href="http://matlab.sfstoolbox.org/">Matlab</a>
+		<a class="active" href="http://python.sfstoolbox.org/">Python</a>
+	</div> 
+
+{% endblock %}

--- a/doc/_template/layout.html
+++ b/doc/_template/layout.html
@@ -6,9 +6,9 @@
   {% include "searchbox.html" %}
 
 	<div class="rtd-nav">
-		<a href="http://sfstoolbox.org/">Theory</a>
-		<a href="http://matlab.sfstoolbox.org/">Matlab</a>
-		<a class="active" href="http://python.sfstoolbox.org/">Python</a>
+		<a href="http://sfstoolbox.org">Theory</a>
+		<a href="http://matlab.sfstoolbox.org">Matlab</a>
+		<a class="active" href="{{ pathto(master_doc) }}">Python</a>
 	</div> 
 
 {% endblock %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -70,7 +70,7 @@ plot_html_show_formats = False
 plot_pre_code = ""
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['_template']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -83,7 +83,7 @@ master_doc = 'index'
 
 # General information about the project.
 authors = 'SFS Toolbox Developers'
-project = 'Sound Field Synthesis Toolbox'
+project = 'SFS Toolbox'
 copyright = '2017, ' + authors
 
 # The version info for the project you're documenting, acts as replacement for
@@ -143,6 +143,10 @@ pygments_style = 'sphinx'
 
 
 # -- Options for HTML output ----------------------------------------------
+
+def setup(app):
+    """Include custom theme files to sphinx HTML header"""
+    app.add_stylesheet('css/title.css')
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.


### PR DESCRIPTION
To make it more obvious that we three different sub-projects under SFS Toolbox I created a small navigation on the right side. You can preview it at http://python.sfstoolbox.org/en/nav/

![sfs-python](https://user-images.githubusercontent.com/173624/34796319-10c44a04-f64d-11e7-94fb-2eb344f56905.png)

A few remarks:
1) The last commit has to be deleted before merging
2) The related pull requests https://github.com/sfstoolbox/theory/pull/25 and https://github.com/sfstoolbox/sfs-matlab/pull/180 have to be merged as well
3) For the matlab and python version we also have to make an official release as the default url points to their last stable release
