### PR TITLE
Clip soundfield into float64 range for plotting

### DIFF
--- a/sfs/plot.py
+++ b/sfs/plot.py
@@ -285,6 +285,7 @@ def soundfield(p, grid, xnorm=None, cmap='coolwarm_clip', vmin=-2.0, vmax=2.0,
     if ax is None:
         ax = plt.gca()
 
+    # see https://github.com/matplotlib/matplotlib/issues/10567
     if matplotlib_version.startswith('2.1.'):
         p = np.clip(p, -1e15, 1e15)  # clip to float64 range
 

--- a/sfs/plot.py
+++ b/sfs/plot.py
@@ -1,6 +1,7 @@
 """Plot sound fields etc."""
 from __future__ import division
 import matplotlib.pyplot as plt
+from matplotlib import __version__ as matplotlib_version
 from matplotlib.patches import PathPatch
 from matplotlib.path import Path
 from matplotlib.collections import PatchCollection
@@ -284,8 +285,8 @@ def soundfield(p, grid, xnorm=None, cmap='coolwarm_clip', vmin=-2.0, vmax=2.0,
     if ax is None:
         ax = plt.gca()
 
-    # clip to float64 range for matplotlib 2.1, see #50
-    p = np.clip(p, -1e15, 1e15)
+    if matplotlib_version.startswith('2.1.'):
+        p = np.clip(p, -1e15, 1e15)  # clip to float64 range
 
     im = ax.imshow(np.real(p), cmap=cmap, origin='lower',
                    extent=[x.min(), x.max(), y.min(), y.max()],

--- a/sfs/plot.py
+++ b/sfs/plot.py
@@ -284,6 +284,9 @@ def soundfield(p, grid, xnorm=None, cmap='coolwarm_clip', vmin=-2.0, vmax=2.0,
     if ax is None:
         ax = plt.gca()
 
+    # clip to float64 range for matplotlib 2.1, see #50
+    p = np.clip(p, -1e15, 1e15)
+
     im = ax.imshow(np.real(p), cmap=cmap, origin='lower',
                    extent=[x.min(), x.max(), y.min(), y.max()],
                    vmax=vmax, vmin=vmin, **kwargs)


### PR DESCRIPTION
closes #50 

(This may become obsolete in matplotlib 2.2 or not.
Since it's easy enough, I propose to fix it now anyway.)