### PR TITLE
Fix cart2sph to reflect correct range and update tests.

### DIFF
--- a/sfs/util.py
+++ b/sfs/util.py
@@ -123,6 +123,7 @@ def cart2sph(x, y, z):
     """
     r = np.sqrt(x**2 + y**2 + z**2)
     alpha = np.arctan2(y, x)
+    alpha = alpha % (2 * np.pi)  # [0, 2pi)
     beta = np.arccos(z / r)
     return alpha, beta, r
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,14 +4,18 @@ import pytest
 import sfs
 
 cart_sph_data = [
-    ((1, 1, 1), (np.pi/4, np.arccos(1/np.sqrt(3)), np.sqrt(3))),
-    ((-1, 1, 1), (np.arctan2(1, -1), np.arccos(1/np.sqrt(3)), np.sqrt(3))),
-    ((1, -1, 1), (-np.pi/4, np.arccos(1/np.sqrt(3)), np.sqrt(3))),
-    ((-1, -1, 1), (np.arctan2(-1, -1), np.arccos(1/np.sqrt(3)), np.sqrt(3))),
-    ((1, 1, -1), (np.pi/4, np.arccos(-1/np.sqrt(3)), np.sqrt(3))),
-    ((-1, 1, -1), (np.arctan2(1, -1), np.arccos(-1/np.sqrt(3)), np.sqrt(3))),
-    ((1, -1, -1), (-np.pi/4, np.arccos(-1/np.sqrt(3)), np.sqrt(3))),
-    ((-1, -1, -1), (np.arctan2(-1, -1), np.arccos(-1/np.sqrt(3)), np.sqrt(3))),
+    ((1, 1, 1), (np.pi / 4, np.arccos(1 / np.sqrt(3)), np.sqrt(3))),
+    ((-1, 1, 1), (3 * np.pi / 4, np.arccos(1 / np.sqrt(3)), np.sqrt(3))),
+    ((1, -1, 1), (2 * np.pi - np.pi / 4, np.arccos(1 / np.sqrt(3)),
+                  np.sqrt(3))),
+    ((-1, -1, 1), (2 * np.pi - 3 * np.pi / 4, np.arccos(1 / np.sqrt(3)),
+                   np.sqrt(3))),
+    ((1, 1, -1), (np.pi / 4, np.arccos(-1 / np.sqrt(3)), np.sqrt(3))),
+    ((-1, 1, -1), (3 * np.pi / 4, np.arccos(-1 / np.sqrt(3)), np.sqrt(3))),
+    ((1, -1, -1), (2 * np.pi - np.pi / 4, np.arccos(-1 / np.sqrt(3)),
+                   np.sqrt(3))),
+    ((-1, -1, -1), (2 * np.pi - 3 * np.pi / 4, np.arccos(-1 / np.sqrt(3)),
+                    np.sqrt(3))),
 ]
 
 


### PR DESCRIPTION
This is the PR for https://github.com/sfstoolbox/sfs-python/issues/59.
Testing against `np.arctan2` is not meaningful, since this is causing the range issue.