### PR TITLE
Fix db for power quantities

### DIFF
--- a/sfs/util.py
+++ b/sfs/util.py
@@ -362,7 +362,7 @@ def db(x, power=False):
 
     """
     with np.errstate(divide='ignore'):
-        return 10 if power else 20 * np.log10(np.abs(x))
+        return 0.5 * db(x) if power else 20 * np.log10(np.abs(x))
 
 
 class XyzComponents(np.ndarray):


### PR DESCRIPTION
`db(x)` is always returning `10` for `power=True`.