### PR TITLE
DOC: Make LaTeX math definitions LaTeX compatible

### DIFF
--- a/doc/math-definitions.rst
+++ b/doc/math-definitions.rst
@@ -1,10 +1,22 @@
+.. raw:: latex
+
+    $
+
 .. rst-class:: hidden
 .. math::
-    \newcommand{\dirac}[1]{\operatorname{\delta}\left(#1\right)}
-    \newcommand{\e}[1]{\operatorname{e}^{#1}}
-    \newcommand{\Hankel}[3]{\mathop{{}H_{#2}^{(#1)}}\!\left(#3\right)}
-    \newcommand{\hankel}[3]{\mathop{{}h_{#2}^{(#1)}}\!\left(#3\right)}
-    \newcommand{\i}{\mathrm{i}}
-    \newcommand{\scalarprod}[2]{\left\langle#1,#2\right\rangle}
-    \renewcommand{\vec}[1]{\mathbf{#1}}
-    \newcommand{\wc}{\frac{\omega}{c}}
+    :nowrap:
+
+    $
+    \def\dirac#1{\operatorname{\delta}\left(#1\right)}
+    \def\e#1{\operatorname{e}^{#1}}
+    \def\Hankel#1#2#3{\mathop{{}H_{#2}^{(#1)}}\!\left(#3\right)}
+    \def\hankel#1#2#3{\mathop{{}h_{#2}^{(#1)}}\!\left(#3\right)}
+    \def\i{\mathrm{i}}
+    \def\scalarprod#1#2{\left\langle#1,#2\right\rangle}
+    \def\vec#1{\mathbf{#1}}
+    \def\wc{\frac{\omega}{c}}
+    $
+
+.. raw:: latex
+
+    $


### PR DESCRIPTION
Our math definitions cause problems when creating LaTeX output because they are not actually LaTeX compatible, they just happen to work with MathJax.

There are two reasons why this doesn't work in LaTeX:

* the definitions are included multiple times, leading to `\newcommand` complaining about already defined macros
* While in MathJax we need to be in math mode for anything to work, in LaTeX the `\newcommand` doesn't work in math mode.

My work-around is admittedly a bit non-obvious, does anyone have a better idea how to fix this?