### PR TITLE
Adjust axis limits in sound field plots

### DIFF
--- a/sfs/plot.py
+++ b/sfs/plot.py
@@ -283,6 +283,9 @@ def soundfield(p, grid, xnorm=None, cmap='coolwarm_clip', vmin=-2.0, vmax=2.0,
     elif plotting_plane == 'yz':
         x, y = grid[[1, 2]]
 
+    dx = np.asscalar(np.diff(x[0, :2])) / 2
+    dy = np.asscalar(np.diff(y[:2, 0])) / 2
+
     if ax is None:
         ax = plt.gca()
 
@@ -291,7 +294,7 @@ def soundfield(p, grid, xnorm=None, cmap='coolwarm_clip', vmin=-2.0, vmax=2.0,
         p = np.clip(p, -1e15, 1e15)  # clip to float64 range
 
     im = ax.imshow(np.real(p), cmap=cmap, origin='lower',
-                   extent=[x.min(), x.max(), y.min(), y.max()],
+                   extent=[x.min()-dx, x.max()+dx, y.min()-dy, y.max()+dy],
                    vmax=vmax, vmin=vmin, **kwargs)
     if xlabel is None:
         xlabel = plotting_plane[0] + ' / m'

--- a/sfs/plot.py
+++ b/sfs/plot.py
@@ -283,8 +283,8 @@ def soundfield(p, grid, xnorm=None, cmap='coolwarm_clip', vmin=-2.0, vmax=2.0,
     elif plotting_plane == 'yz':
         x, y = grid[[1, 2]]
 
-    dx = np.asscalar(np.diff(x[0, :2])) / 2
-    dy = np.asscalar(np.diff(y[:2, 0])) / 2
+    dx = 0.5 * x.ptp() / p.shape[0]
+    dy = 0.5 * y.ptp() / p.shape[1]
 
     if ax is None:
         ax = plt.gca()


### PR DESCRIPTION
Before
![soundfield_before](https://user-images.githubusercontent.com/8125968/53561828-1fe47880-3b50-11e9-9a51-75394ed4d551.png)

After
![soundfield_after](https://user-images.githubusercontent.com/8125968/53561832-22df6900-3b50-11e9-855b-be006d2706de.png)

These plots are generated by

        sfs-python/doc/examples/sound_field_synthesis.py
      
with 

```python
grid = sfs.util.xyz_grid([-2, 2], [-2, 2], 0, spacing=0.5)
```