### PR TITLE
Documentation of driving functions

### DIFF
--- a/sfs/mono/drivingfunction.py
+++ b/sfs/mono/drivingfunction.py
@@ -40,8 +40,31 @@ from .. import default
 
 
 def wfs_2d_line(omega, x0, n0, xs, c=None):
-    r"""Line source by 2-dimensional WFS.
+    r"""Driving function for 2-dimensional WFS for a virtual line source.
 
+    Parameters
+    ----------
+    omega : float
+        Frequency of line source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    xs : (3,) array_like
+        Position of virtual line source.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
+    .. math::
+
+        V(\x,\w) = \frac{1}{\rho c} \e{-\i\wc\n\x} \n
     .. math::
 
         D(\x_0,\w) = \frac{\i}{2} \wc
@@ -68,8 +91,28 @@ def wfs_2d_line(omega, x0, n0, xs, c=None):
 
 
 def _wfs_point(omega, x0, n0, xs, c=None):
-    r"""Point source by two- or three-dimensional WFS.
+    r"""Driving function for 2/3-dimensional WFS for a virtual point source.
 
+    Parameters
+    ----------
+    omega : float
+        Frequency of line source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    xs : (3,) array_like
+        Position of virtual point source.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
     .. math::
 
         D(\x_0, \w) = \i\wc \frac{\scalarprod{\x_0-\x_\text{s}}{\n_0}}
@@ -99,8 +142,30 @@ wfs_2d_point = _wfs_point
 
 
 def wfs_25d_point(omega, x0, n0, xs, xref=[0, 0, 0], c=None, omalias=None):
-    r"""Point source by 2.5-dimensional WFS.
+    r"""Driving function for 2.5-dimensional WFS for a virtual point source.
 
+    Parameters
+    ----------
+    omega : float
+        Frequency of line source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    xs : (3,) array_like
+        Position of virtual point source.
+    xref : (3,) array_like
+        Reference point for synthesized sound field.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
     .. math::
 
         D(\x_0,\w) = \sqrt{\i\wc |\x_\text{ref}-\x_0|}
@@ -135,8 +200,28 @@ wfs_3d_point = _wfs_point
 
 
 def _wfs_plane(omega, x0, n0, n=[0, 1, 0], c=None):
-    r"""Plane wave by two- or three-dimensional WFS.
+    r"""Driving function for 2/3-dimensional WFS for a virtual plane wave.
 
+    Parameters
+    ----------
+    omega : float
+        Frequency of line source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    n : (3,) array_like
+        Normal vector (traveling direction) of plane wave.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
     Eq.(17) from :cite:`Spors2008`:
 
     .. math::
@@ -166,8 +251,32 @@ wfs_2d_plane = _wfs_plane
 
 def wfs_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None,
                   omalias=None):
-    r"""Plane wave by 2.5-dimensional WFS.
+    r"""Driving function for 2.5-dimensional WFS for a virtual plane wave.
 
+    Parameters
+    ----------
+    omega : float
+        Frequency of line source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    n : (3,) array_like
+        Normal vector (traveling direction) of plane wave.
+    xref : (3,) array_like
+        Reference point for synthesized sound field.
+    c : float, optional
+        Speed of sound.
+    omalias: float, optional
+        Angular frequency where spatial aliasing becomes prominent.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
     .. math::
 
         D_\text{2.5D}(\x_0,\w) = \sqrt{\i\wc |\x_\text{ref}-\x_0|}
@@ -198,8 +307,28 @@ wfs_3d_plane = _wfs_plane
 
 
 def _wfs_focused(omega, x0, n0, xs, c=None):
-    r"""Focused source by two- or three-dimensional WFS.
+    r"""Driving function for 2/3-dimensional WFS for a focused source.
 
+    Parameters
+    ----------
+    omega : float
+        Frequency of line source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    xs : (3,) array_like
+        Position of focused source.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
     .. math::
 
         D(\x_0,\w) = \i\wc \frac{\scalarprod{\x_0-\x_\text{s}}{\n_0}}
@@ -229,8 +358,32 @@ wfs_2d_focused = _wfs_focused
 
 
 def wfs_25d_focused(omega, x0, n0, xs, xref=[0, 0, 0], c=None, omalias=None):
-    r"""Focused source by 2.5-dimensional WFS.
+    r"""Driving function for 2.5-dimensional WFS for a focused source.
 
+    Parameters
+    ----------
+    omega : float
+        Frequency of line source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    xs : (3,) array_like
+        Position of focused source.
+    xref : (3,) array_like
+        Reference point for synthesized sound field.
+    c : float, optional
+        Speed of sound.
+    omalias: float, optional
+        Angular frequency where spatial aliasing becomes prominent.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
     .. math::
 
         D(\x_0,\w) = \sqrt{\i\wc |\x_\text{ref}-\x_0|}
@@ -265,7 +418,32 @@ wfs_3d_focused = _wfs_focused
 
 
 def wfs_25d_preeq(omega, omalias, c):
-    """Preqeualization for 2.5D WFS."""
+    r"""Pre-equalization filter for 2.5-dimensional WFS.
+
+    Parameters
+    ----------
+    omega : float
+        Angular frequency.
+    omalias: float
+        Angular frequency where spatial aliasing becomes prominent.
+    c : float
+        Speed of sound.
+
+    Returns
+    -------
+    float
+        Complex weight for given angular frequency.
+
+    Notes
+    -----
+    .. math::
+
+        H(\w) = \begin{cases}
+            \sqrt{\i \wc} & \text{for } \w <= \w_\text{alias} \\
+            \sqrt{\i \frac{\w_\text{alias}}{c}} & \text{for } \w > \w_\text{alias}
+            \end{cases}
+
+    """
     if omalias is None:
         return np.sqrt(1j * util.wavenumber(omega, c))
     else:
@@ -276,7 +454,42 @@ def wfs_25d_preeq(omega, omalias, c):
 
 
 def delay_3d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
-    """Plane wave by simple delay of secondary sources."""
+    r"""Delay-only driving function for a virtual plane wave.
+
+    Parameters
+    ----------
+    omega : float
+        Frequency of line source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    n : (3,) array_like
+        Normal vector (traveling direction) of plane wave.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
+    .. math::
+
+        D(\x_0,\w) = \e{-\i\wc\scalarprod{\n}{\x_0}}
+
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        d = sfs.mono.drivingfunction.delay_3d_plane(omega, x0, n0, npw)
+        a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+        plot(d, a)
+
+    """
     x0 = util.asarray_of_rows(x0)
     n = util.normalize_vector(n)
     k = util.wavenumber(omega, c)
@@ -284,9 +497,30 @@ def delay_3d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
 
 
 def source_selection_plane(n0, n):
-    """Secondary source selection for a plane wave.
+    r"""Secondary source selection for a virtual plane wave.
 
+    Parameters
+    ----------
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    n : (3,) array_like
+        Normal vector (traveling direction) of plane wave.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Active secondary sources.
+
+    Notes
+    -----
     Eq.(13) from :cite:`Spors2008`
+
+    .. math::
+
+        a(\x_0) = \begin{cases}
+            1 & \text{for } \scalarprod{\n}{\n_0} > 0 \\
+            0 & \text{otherwise}
+            \end{cases}
 
     """
     n0 = util.asarray_of_rows(n0)
@@ -295,9 +529,32 @@ def source_selection_plane(n0, n):
 
 
 def source_selection_point(n0, x0, xs):
-    """Secondary source selection for a point source.
+    r"""Secondary source selection for a virtual line/point source.
 
+    Parameters
+    ----------
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    xs : (3,) array_like
+        Position of line/point source.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Active secondary sources.
+
+    Notes
+    -----
     Eq.(15) from :cite:`Spors2008`
+
+    .. math::
+
+        a(\x_0) = \begin{cases}
+            1 & \text{for } \scalarprod{\x_0 - \x_s}{\n_0} > 0 \\
+            0 & \text{otherwise}
+            \end{cases}
 
     """
     n0 = util.asarray_of_rows(n0)
@@ -307,17 +564,28 @@ def source_selection_point(n0, x0, xs):
     return inner1d(ds, n0) >= default.selection_tolerance
 
 
-def source_selection_line(n0, x0, xs):
-    """Secondary source selection for a line source.
-
-    compare Eq.(15) from :cite:`Spors2008`
-
-    """
-    return source_selection_point(n0, x0, xs)
+source_selection_line = source_selection_point
 
 
 def source_selection_focused(ns, x0, xs):
-    """Secondary source selection for a focused source.
+    r"""Secondary source selection for a focused source.
+
+    Parameters
+    ----------
+    ns : (3,) array_like
+        Normal vector of focused source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    xs : (3,) array_like
+        Position of focused source.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Active secondary sources.
+
+    Notes
+    -----
 
     Eq.(2.78) from :cite:`Wierstorf2014`
 
@@ -330,12 +598,46 @@ def source_selection_focused(ns, x0, xs):
 
 
 def source_selection_all(N):
-    """Select all secondary sources."""
+    r"""Selects all secondary sources as active.
+
+    Parameters
+    ----------
+    N : int
+        Total number of seconadary sources.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Active secondary sources.
+    """
     return np.ones(N, dtype=bool)
 
 
 def nfchoa_2d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
-    r"""Plane wave by two-dimensional NFC-HOA.
+    r"""Driving function for 2-dimensional NFC-HOA for a virtual plane wave.
+
+    Parameters
+    ----------
+    omega : float
+        Angular frequency of plane wave.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    r0 : float
+        Radius of circular secondary source distribution.
+    n : (3,) array_like
+        Normal vector (traveling direction) of plane wave.
+    max_order : float, optional
+        Maximum order of circular harmonics used for the calculation.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
 
     .. math::
 
@@ -369,8 +671,30 @@ def nfchoa_2d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
 
 
 def nfchoa_25d_point(omega, x0, r0, xs, max_order=None, c=None):
-    r"""Point source by 2.5-dimensional NFC-HOA.
+    r"""Driving function for 2.5-dimensional NFC-HOA for a virtual point source.
 
+    Parameters
+    ----------
+    omega : float
+        Angular frequency of point source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    r0 : float
+        Radius of circular secondary source distribution.
+    xs : (3,) array_like
+        Position of point source.
+    max_order : float, optional
+        Maximum order of circular harmonics used for the calculation.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
     .. math::
 
         D(\phi_0, \omega) =
@@ -405,8 +729,30 @@ def nfchoa_25d_point(omega, x0, r0, xs, max_order=None, c=None):
 
 
 def nfchoa_25d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
-    r"""Plane wave by 2.5-dimensional NFC-HOA.
+    r"""Driving function for 2.5-dimensional NFC-HOA for a virtual plane wave.
 
+    Parameters
+    ----------
+    omega : float
+        Angular frequency of point source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    r0 : float
+        Radius of circular secondary source distribution.
+    n : (3,) array_like
+        Normal vector (traveling direction) of plane wave.
+    max_order : float, optional
+        Maximum order of circular harmonics used for the calculation.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
     .. math::
 
         D(\phi_0, \omega) =
@@ -439,11 +785,61 @@ def nfchoa_25d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
     return 2*1j / r0 * d
 
 
+def _max_order_circular_harmonics(N, max_order):
+    r"""Compute maximum order of the circular harmonics expansion for
+    2-dimensional HOA.
+
+    Parameters
+    ----------
+    N : int
+        Number of secondary sources.
+    max_order : int
+        Maximum order of expansion. If None maximum order is calculated.
+
+    Returns
+    -------
+    int
+        Maximum order.
+
+    """
+    return N // 2 if max_order is None else max_order
+
+
 def sdm_2d_line(omega, x0, n0, xs, c=None):
-    """Line source by two-dimensional SDM.
+    r"""Driving function for 2-dimensional SDM for a virtual line source.
+
+    Parameters
+    ----------
+    omega : float
+        Angular frequency of line source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    xs : (3,) array_like
+        Position of line source.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
 
     The secondary sources have to be located on the x-axis (y0=0).
     Derived from :cite:`Spors2009`, Eq.(9), Eq.(4).
+
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        x0, n0, a0 = sfs.array.linear(32, 0.2, orientation=[0, -1, 0])
+        d = sfs.mono.drivingfunction.sdm_2d_line(omega, x0, n0, xs)
+        plot(d, 1)
 
     """
     x0 = util.asarray_of_rows(x0)
@@ -456,7 +852,28 @@ def sdm_2d_line(omega, x0, n0, xs, c=None):
 
 
 def sdm_2d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
-    r"""Plane wave by two-dimensional SDM.
+    r"""Driving function for 2-dimensional SDM for a virtual plane wave.
+
+    Parameters
+    ----------
+    omega : float
+        Angular frequency of plane wave.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    n: (3,) array_like
+        Normal vector (traveling direction) of plane wave.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
 
     The secondary sources have to be located on the x-axis (y0=0).
     Derived from :cite:`Ahrens2012`, Eq.(3.73), Eq.(C.5), Eq.(C.11):
@@ -464,6 +881,15 @@ def sdm_2d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     .. math::
 
         D(\x_0,k) = k_\text{pw,y} \e{-\i k_\text{pw,x} x}
+
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        x0, n0, a0 = sfs.array.linear(32, 0.2, orientation=[0, -1, 0])
+        d = sfs.mono.drivingfunction.sdm_2d_plane(omega, x0, n0, npw)
+        plot(d, 1)
 
     """
     x0 = util.asarray_of_rows(x0)
@@ -474,10 +900,42 @@ def sdm_2d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
 
 
 def sdm_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
-    """Plane wave by 2.5-dimensional SDM.
+    r"""Driving function for 2.5-dimensional SDM for a virtual plane wave.
+
+    Parameters
+    ----------
+    omega : float
+        Angular frequency of plane wave.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    n: (3,) array_like
+        Normal vector (traveling direction) of plane wave.
+    xref : (3,) array_like, optional
+        Reference point for synthesized sound field.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
 
     The secondary sources have to be located on the x-axis (y0=0).
     Eq.(3.79) from :cite:`Ahrens2012`.
+
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        x0, n0, a0 = sfs.array.linear(32, 0.2, orientation=[0, -1, 0])
+        d = sfs.mono.drivingfunction.sdm_25d_plane(omega, x0, n0, npw, [0, -1, 0])
+        plot(d, 1)
 
     """
     x0 = util.asarray_of_rows(x0)
@@ -490,10 +948,42 @@ def sdm_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
 
 
 def sdm_25d_point(omega, x0, n0, xs, xref=[0, 0, 0], c=None):
-    """Point source by 2.5-dimensional SDM.
+    r"""Driving function for 2.5-dimensional SDM for a virtual point source.
+
+    Parameters
+    ----------
+    omega : float
+        Angular frequency of point source.
+    x0 : (N, 3) array_like
+        Sequence of secondary source positions.
+    n0 : (N, 3) array_like
+        Sequence of normal vectors of secondary sources.
+    xs: (3,) array_like
+        Position of virtual point source.
+    xref : (3,) array_like, optional
+        Reference point for synthesized sound field.
+    c : float, optional
+        Speed of sound.
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
 
     The secondary sources have to be located on the x-axis (y0=0).
-    Driving funcnction from :cite:`Spors2010`, Eq.(24).
+    Driving function from :cite:`Spors2010`, Eq.(24).
+
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        x0, n0, a0 = sfs.array.linear(32, 0.2, orientation=[0, -1, 0])
+        d = sfs.mono.drivingfunction.sdm_25d_point(omega, x0, n0, xs, [0, -1, 0])
+        plot(d, 1)
 
     """
     x0 = util.asarray_of_rows(x0)
@@ -509,13 +999,9 @@ def sdm_25d_point(omega, x0, n0, xs, xref=[0, 0, 0], c=None):
 
 def esa_edge_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
                       c=None):
-    """Plane wave by two-dimensional ESA for an edge-shaped secondary source
-       distribution consisting of monopole line sources.
-
-    One leg of the secondary sources has to be located on the x-axis (y0=0),
-    the edge at the origin.
-
-    Derived from :cite:`Spors2016`
+    r"""Driving function for a virtual plane wave using the 2-dimensional ESA
+    for an edge-shaped secondary source distribution consisting of
+    monopole line sources.
 
     Parameters
     ----------
@@ -537,6 +1023,13 @@ def esa_edge_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
     -------
     (N,) numpy.ndarray
         Complex weights of secondary sources.
+
+    Notes
+    -----
+    One leg of the secondary sources has to be located on the x-axis (y0=0),
+    the edge at the origin.
+
+    Derived from :cite:`Spors2016`
 
     """
     x0 = np.asarray(x0)
@@ -568,13 +1061,9 @@ def esa_edge_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
 
 def esa_edge_dipole_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
                              c=None):
-    """Plane wave by two-dimensional ESA for an edge-shaped secondary source
-       distribution consisting of dipole line sources.
-
-    One leg of the secondary sources has to be located on the x-axis (y0=0),
-    the edge at the origin.
-
-    Derived from :cite:`Spors2016`
+    r"""Driving function for a virtual plane wave using the 2-dimensional ESA
+    for an edge-shaped secondary source distribution consisting of
+    dipole line sources.
 
     Parameters
     ----------
@@ -596,6 +1085,13 @@ def esa_edge_dipole_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
     -------
     (N,) numpy.ndarray
         Complex weights of secondary sources.
+
+    Notes
+    -----
+    One leg of the secondary sources has to be located on the x-axis (y0=0),
+    the edge at the origin.
+
+    Derived from :cite:`Spors2016`
 
     """
     x0 = np.asarray(x0)
@@ -624,13 +1120,9 @@ def esa_edge_dipole_2d_plane(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
 
 
 def esa_edge_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
-    """Line source by two-dimensional ESA for an edge-shaped secondary source
-       distribution constisting of monopole line sources.
-
-    One leg of the secondary sources have to be located on the x-axis (y0=0),
-    the edge at the origin.
-
-    Derived from :cite:`Spors2016`
+    r"""Driving function for a virtual line source using the 2-dimensional ESA
+    for an edge-shaped secondary source distribution consisting of line
+    sources.
 
     Parameters
     ----------
@@ -652,6 +1144,13 @@ def esa_edge_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     -------
     (N,) numpy.ndarray
         Complex weights of secondary sources.
+
+    Notes
+    -----
+    One leg of the secondary sources has to be located on the x-axis (y0=0),
+    the edge at the origin.
+
+    Derived from :cite:`Spors2016`
 
     """
     x0 = np.asarray(x0)
@@ -685,61 +1184,10 @@ def esa_edge_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     return -1j*np.pi/alpha * d
 
 
-def esa_edge_25d_point(omega, x0, xs, xref=[2, -2, 0], alpha=3/2*np.pi,
-                       Nc=None, c=None):
-    """Point source by 2.5-dimensional ESA for an edge-shaped secondary source
-       distribution constisting of monopole line sources.
-
-    One leg of the secondary sources have to be located on the x-axis (y0=0),
-    the edge at the origin.
-
-    Derived from :cite:`Spors2016`
-
-    Parameters
-    ----------
-    omega : float
-        Angular frequency.
-    x0 : int(N, 3) array_like
-        Sequence of secondary source positions.
-    xs : (3,) array_like
-        Position of synthesized line source.
-    xref: (3,) array_like or float
-        Reference position or reference distance
-    alpha : float, optional
-        Outer angle of edge.
-    Nc : int, optional
-        Number of elements for series expansion of driving function. Estimated
-        if not given.
-    c : float, optional
-        Speed of sound
-
-    Returns
-    -------
-    (N,) numpy.ndarray
-        Complex weights of secondary sources.
-
-    """
-    x0 = np.asarray(x0)
-    xs = np.asarray(xs)
-    xref = np.asarray(xref)
-
-    if np.isscalar(xref):
-        a = np.linalg.norm(xref)/np.linalg.norm(xref-xs)
-    else:
-        a = np.linalg.norm(xref-x0, axis=1)/np.linalg.norm(xref-xs)
-
-    return 1j*np.sqrt(a) * esa_edge_2d_line(omega, x0, xs, alpha=alpha, Nc=Nc,
-                                            c=c)
-
-
 def esa_edge_dipole_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
-    """Line source by two-dimensional ESA for an edge-shaped secondary source
-       distribution constisting of dipole line sources.
-
-    One leg of the secondary sources have to be located on the x-axis (y0=0),
-    the edge at the origin.
-
-    Derived from :cite:`Spors2016`
+    r"""Driving function for a virtual line source using the 2-dimensional ESA
+    for an edge-shaped secondary source distribution consisting of dipole line
+    sources.
 
     Parameters
     ----------
@@ -761,6 +1209,13 @@ def esa_edge_dipole_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     -------
     (N,) numpy.ndarray
         Complex weights of secondary sources.
+    
+    Notes
+    -----
+    One leg of the secondary sources has to be located on the x-axis (y0=0),
+    the edge at the origin.
+
+    Derived from :cite:`Spors2016`
 
     """
     x0 = np.asarray(x0)
@@ -792,6 +1247,51 @@ def esa_edge_dipole_2d_line(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     return -1j*np.pi/alpha * d
 
 
-def _max_order_circular_harmonics(N, max_order):
-    """Compute order of 2D HOA."""
-    return N // 2 if max_order is None else max_order
+def esa_edge_25d_point(omega, x0, xs, xref=[2, -2, 0], alpha=3/2*np.pi,
+                       Nc=None, c=None):
+    r"""Driving function for a virtual point source using the 2.5-dimensional
+    ESA for an edge-shaped secondary source distribution consisting of point
+    sources.
+
+    Parameters
+    ----------
+    omega : float
+        Angular frequency.
+    x0 : int(N, 3) array_like
+        Sequence of secondary source positions.
+    xs : (3,) array_like
+        Position of synthesized line source.
+    xref: (3,) array_like or float
+        Reference position or reference distance
+    alpha : float, optional
+        Outer angle of edge.
+    Nc : int, optional
+        Number of elements for series expansion of driving function. Estimated
+        if not given.
+    c : float, optional
+        Speed of sound
+
+    Returns
+    -------
+    (N,) numpy.ndarray
+        Complex weights of secondary sources.
+
+    Notes
+    -----
+    One leg of the secondary sources has to be located on the x-axis (y0=0),
+    the edge at the origin.
+
+    Derived from :cite:`Spors2016`
+
+    """
+    x0 = np.asarray(x0)
+    xs = np.asarray(xs)
+    xref = np.asarray(xref)
+
+    if np.isscalar(xref):
+        a = np.linalg.norm(xref)/np.linalg.norm(xref-xs)
+    else:
+        a = np.linalg.norm(xref-x0, axis=1)/np.linalg.norm(xref-xs)
+
+    return 1j*np.sqrt(a) * esa_edge_2d_line(omega, x0, xs, alpha=alpha, Nc=Nc,
+                                            c=c)

--- a/sfs/mono/drivingfunction.py
+++ b/sfs/mono/drivingfunction.py
@@ -45,7 +45,7 @@ def wfs_2d_line(omega, x0, n0, xs, c=None):
     Parameters
     ----------
     omega : float
-        Frequency of line source.
+        Angular frequency of line source.
     x0 : (N, 3) array_like
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
@@ -62,9 +62,6 @@ def wfs_2d_line(omega, x0, n0, xs, c=None):
 
     Notes
     -----
-    .. math::
-
-        V(\x,\w) = \frac{1}{\rho c} \e{-\i\wc\n\x} \n
     .. math::
 
         D(\x_0,\w) = \frac{\i}{2} \wc
@@ -96,7 +93,7 @@ def _wfs_point(omega, x0, n0, xs, c=None):
     Parameters
     ----------
     omega : float
-        Frequency of line source.
+        Angular frequency of point source.
     x0 : (N, 3) array_like
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
@@ -147,14 +144,14 @@ def wfs_25d_point(omega, x0, n0, xs, xref=[0, 0, 0], c=None, omalias=None):
     Parameters
     ----------
     omega : float
-        Frequency of line source.
+        Angular frequency of point source.
     x0 : (N, 3) array_like
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
         Sequence of normal vectors of secondary sources.
     xs : (3,) array_like
         Position of virtual point source.
-    xref : (3,) array_like
+    xref : (3,) array_like, optional
         Reference point for synthesized sound field.
     c : float, optional
         Speed of sound.
@@ -205,12 +202,12 @@ def _wfs_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     Parameters
     ----------
     omega : float
-        Frequency of line source.
+        Angular frequency of plane wave.
     x0 : (N, 3) array_like
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
         Sequence of normal vectors of secondary sources.
-    n : (3,) array_like
+    n : (3,) array_like, optional
         Normal vector (traveling direction) of plane wave.
     c : float, optional
         Speed of sound.
@@ -256,14 +253,14 @@ def wfs_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None,
     Parameters
     ----------
     omega : float
-        Frequency of line source.
+        Angular frequency of plane wave.
     x0 : (N, 3) array_like
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
         Sequence of normal vectors of secondary sources.
-    n : (3,) array_like
+    n : (3,) array_like, optional
         Normal vector (traveling direction) of plane wave.
-    xref : (3,) array_like
+    xref : (3,) array_like, optional
         Reference point for synthesized sound field.
     c : float, optional
         Speed of sound.
@@ -312,7 +309,7 @@ def _wfs_focused(omega, x0, n0, xs, c=None):
     Parameters
     ----------
     omega : float
-        Frequency of line source.
+        Angular frequency of focused source.
     x0 : (N, 3) array_like
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
@@ -363,14 +360,14 @@ def wfs_25d_focused(omega, x0, n0, xs, xref=[0, 0, 0], c=None, omalias=None):
     Parameters
     ----------
     omega : float
-        Frequency of line source.
+        Angular frequency of focused source.
     x0 : (N, 3) array_like
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
         Sequence of normal vectors of secondary sources.
     xs : (3,) array_like
         Position of focused source.
-    xref : (3,) array_like
+    xref : (3,) array_like, optional
         Reference point for synthesized sound field.
     c : float, optional
         Speed of sound.
@@ -459,12 +456,12 @@ def delay_3d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     Parameters
     ----------
     omega : float
-        Frequency of line source.
+        Angular frequency of plane wave.
     x0 : (N, 3) array_like
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
         Sequence of normal vectors of secondary sources.
-    n : (3,) array_like
+    n : (3,) array_like, optional
         Normal vector (traveling direction) of plane wave.
     c : float, optional
         Speed of sound.
@@ -609,6 +606,14 @@ def source_selection_all(N):
     -------
     (N,) numpy.ndarray
         Active secondary sources.
+
+    Notes
+    -----
+
+    .. math::
+
+        a(\x_0) = 1
+
     """
     return np.ones(N, dtype=bool)
 
@@ -624,7 +629,7 @@ def nfchoa_2d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
         Sequence of secondary source positions.
     r0 : float
         Radius of circular secondary source distribution.
-    n : (3,) array_like
+    n : (3,) array_like, optional
         Normal vector (traveling direction) of plane wave.
     max_order : float, optional
         Maximum order of circular harmonics used for the calculation.
@@ -739,7 +744,7 @@ def nfchoa_25d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
         Sequence of secondary source positions.
     r0 : float
         Radius of circular secondary source distribution.
-    n : (3,) array_like
+    n : (3,) array_like, optional
         Normal vector (traveling direction) of plane wave.
     max_order : float, optional
         Maximum order of circular harmonics used for the calculation.
@@ -792,14 +797,14 @@ def _max_order_circular_harmonics(N, max_order):
     Parameters
     ----------
     N : int
-        Number of secondary sources.
+        Total number of secondary sources.
     max_order : int
         Maximum order of expansion. If None maximum order is calculated.
 
     Returns
     -------
     int
-        Maximum order.
+        Order.
 
     """
     return N // 2 if max_order is None else max_order
@@ -862,7 +867,7 @@ def sdm_2d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
         Sequence of normal vectors of secondary sources.
-    n: (3,) array_like
+    n: (3,) array_like, optional
         Normal vector (traveling direction) of plane wave.
     c : float, optional
         Speed of sound.
@@ -910,7 +915,7 @@ def sdm_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
         Sequence of secondary source positions.
     n0 : (N, 3) array_like
         Sequence of normal vectors of secondary sources.
-    n: (3,) array_like
+    n: (3,) array_like, optional
         Normal vector (traveling direction) of plane wave.
     xref : (3,) array_like, optional
         Reference point for synthesized sound field.


### PR DESCRIPTION
- Enhanced existing documentation of driving functions
- Added documentation to various driving functions
- New examples for SDM approaches

What should we do about...
- documention of `wfs_3d_point` and `wfs_2d_point` is the same due to their definitions. The examples are a bit misleading in this context. Should we define seperate functions for 2/3-dimensional case? The same holds for `wfs_2d_plane` and `wfs_2d_focused`
- the examples for SDM redefine the circular array to a linear one. Is this OK?