### PR TITLE
Move source selection helpers to sfs.util

### DIFF
--- a/doc/examples/horizontal_plane_arrays.py
+++ b/doc/examples/horizontal_plane_arrays.py
@@ -48,7 +48,7 @@ def compute_and_plot_soundfield(title):
 x0, n0, a0 = sfs.array.linear(N, dx, center=acenter, orientation=anormal)
 
 sourcetype = sfs.mono.source.point
-a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
+a = sfs.util.source_selection_point(n0, x0, xs)
 
 d = sfs.mono.drivingfunction.wfs_3d_point(omega, x0, n0, xs)
 compute_and_plot_soundfield('linear_ps_wfs_3d_point')
@@ -67,7 +67,7 @@ compute_and_plot_soundfield('linear_ls_wfs_2d_line')
 
 # linear array, secondary point sources, virtual plane wave
 sourcetype = sfs.mono.source.point
-a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+a = sfs.util.source_selection_plane(n0, npw)
 
 d = sfs.mono.drivingfunction.wfs_3d_plane(omega, x0, n0, npw)
 compute_and_plot_soundfield('linear_ps_wfs_3d_plane')
@@ -84,11 +84,11 @@ x0, n0, a0 = sfs.array.linear_diff(N//3 * [dx] + N//3 * [dx/2] + N//3 * [dx],
                                    center=acenter, orientation=anormal)
 
 d = sfs.mono.drivingfunction.wfs_25d_point(omega, x0, n0, xs, xref=xnorm)
-a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
+a = sfs.util.source_selection_point(n0, x0, xs)
 compute_and_plot_soundfield('linear_nested_ps_wfs_25d_point')
 
 d = sfs.mono.drivingfunction.wfs_25d_plane(omega, x0, n0, npw, xref=xnorm)
-a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+a = sfs.util.source_selection_plane(n0, npw)
 compute_and_plot_soundfield('linear_nested_ps_wfs_25d_plane')
 
 
@@ -97,22 +97,22 @@ x0, n0, a0 = sfs.array.linear_random(N, dx/2, 1.5*dx, center=acenter,
                                      orientation=anormal)
 
 d = sfs.mono.drivingfunction.wfs_25d_point(omega, x0, n0, xs, xref=xnorm)
-a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
+a = sfs.util.source_selection_point(n0, x0, xs)
 compute_and_plot_soundfield('linear_random_ps_wfs_25d_point')
 
 d = sfs.mono.drivingfunction.wfs_25d_plane(omega, x0, n0, npw, xref=xnorm)
-a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+a = sfs.util.source_selection_plane(n0, npw)
 compute_and_plot_soundfield('linear_random_ps_wfs_25d_plane')
 
 
 # rectangular array, secondary point sources
 x0, n0, a0 = sfs.array.rectangular((N, N//2), dx, center=acenter, orientation=anormal)
 d = sfs.mono.drivingfunction.wfs_25d_point(omega, x0, n0, xs, xref=xnorm)
-a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
+a = sfs.util.source_selection_point(n0, x0, xs)
 compute_and_plot_soundfield('rectangular_ps_wfs_25d_point')
 
 d = sfs.mono.drivingfunction.wfs_25d_plane(omega, x0, n0, npw, xref=xnorm)
-a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+a = sfs.util.source_selection_plane(n0, npw)
 compute_and_plot_soundfield('rectangular_ps_wfs_25d_plane')
 
 
@@ -120,11 +120,11 @@ compute_and_plot_soundfield('rectangular_ps_wfs_25d_plane')
 N = 60
 x0, n0, a0 = sfs.array.circular(N, 1, center=acenter)
 d = sfs.mono.drivingfunction.wfs_25d_point(omega, x0, n0, xs, xref=xnorm)
-a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
+a = sfs.util.source_selection_point(n0, x0, xs)
 compute_and_plot_soundfield('circular_ps_wfs_25d_point')
 
 d = sfs.mono.drivingfunction.wfs_25d_plane(omega, x0, n0, npw, xref=xnorm)
-a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+a = sfs.util.source_selection_plane(n0, npw)
 compute_and_plot_soundfield('circular_ps_wfs_25d_plane')
 
 
@@ -135,7 +135,7 @@ talpha = 0  # switches off tapering
 sourcetype = sfs.mono.source.line
 
 d = sfs.mono.drivingfunction.nfchoa_2d_plane(omega, x0, 1, npw)
-a = sfs.mono.drivingfunction.source_selection_all(N)
+a = sfs.util.source_selection_all(N)
 compute_and_plot_soundfield('circular_ls_nfchoa_2d_plane')
 
 
@@ -146,9 +146,9 @@ talpha = 0  # switches off tapering
 sourcetype = sfs.mono.source.point
 
 d = sfs.mono.drivingfunction.nfchoa_25d_point(omega, x0, 1, xs)
-a = sfs.mono.drivingfunction.source_selection_all(N)
+a = sfs.util.source_selection_all(N)
 compute_and_plot_soundfield('circular_ps_nfchoa_25d_point')
 
 d = sfs.mono.drivingfunction.nfchoa_25d_plane(omega, x0, 1, npw)
-a = sfs.mono.drivingfunction.source_selection_all(N)
+a = sfs.util.source_selection_all(N)
 compute_and_plot_soundfield('circular_ps_nfchoa_25d_plane')

--- a/doc/examples/sound_field_synthesis.py
+++ b/doc/examples/sound_field_synthesis.py
@@ -60,9 +60,9 @@ d = sfs.mono.drivingfunction.wfs_25d_plane(omega, x0, n0, npw, xref)
 #d = sfs.mono.drivingfunction.nfchoa_25d_plane(omega, x0, R, npw)
 
 # === determine active secondary sources ===
-a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
-#a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
-#a = sfs.mono.drivingfunction.source_selection_all(len(x0))
+a = sfs.util.source_selection_plane(n0, npw)
+#a = sfs.util.source_selection_point(n0, x0, xs)
+#a = sfs.util.source_selection_all(len(x0))
 
 
 # === compute tapering window ===

--- a/doc/examples/time_domain.py
+++ b/doc/examples/time_domain.py
@@ -28,7 +28,7 @@ d_delay, d_weight = sfs.time.drivingfunction.wfs_25d_point(x0, n0, xs)
 d = sfs.time.drivingfunction.driving_signals(d_delay, d_weight, signal)
 
 # test soundfield
-a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
+a = sfs.util.source_selection_point(n0, x0, xs)
 twin = sfs.tapering.tukey(a, .3)
 p = sfs.time.soundfield.p_array(x0, d, twin * a0, t, grid)
 p = p * 100  # scale absolute amplitude
@@ -51,7 +51,7 @@ d_delay, d_weight = sfs.time.drivingfunction.wfs_25d_plane(x0, n0, npw)
 d = sfs.time.drivingfunction.driving_signals(d_delay, d_weight, signal)
 
 # test soundfield
-a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+a = sfs.util.source_selection_plane(n0, npw)
 twin = sfs.tapering.tukey(a, .3)
 p = sfs.time.soundfield.p_array(x0, d, twin * a0, t, grid)
 
@@ -72,7 +72,7 @@ d_delay, d_weight = sfs.time.drivingfunction.wfs_25d_focused(x0, n0, xs)
 d = sfs.time.drivingfunction.driving_signals(d_delay, d_weight, signal)
 
 # test soundfield
-a = sfs.mono.drivingfunction.source_selection_focused(nfs, x0, xs)
+a = sfs.util.source_selection_focused(nfs, x0, xs)
 twin = sfs.tapering.tukey(a, .3)
 p = sfs.time.soundfield.p_array(x0, d, twin * a0, t, grid)
 p = p * 100  # scale absolute amplitude

--- a/sfs/mono/drivingfunction.py
+++ b/sfs/mono/drivingfunction.py
@@ -54,7 +54,7 @@ def wfs_2d_line(omega, x0, n0, xs, c=None):
         :context: close-figs
 
         d = sfs.mono.drivingfunction.wfs_2d_line(omega, x0, n0, xs)
-        a = sfs.mono.drivingfunction.source_selection_line(n0, x0, xs)
+        a = sfs.util.source_selection_line(n0, x0, xs)
         plot(d, a)
 
     """
@@ -82,7 +82,7 @@ def _wfs_point(omega, x0, n0, xs, c=None):
         :context: close-figs
 
         d = sfs.mono.drivingfunction.wfs_3d_point(omega, x0, n0, xs)
-        a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
+        a = sfs.util.source_selection_point(n0, x0, xs)
         plot(d, a)
 
     """
@@ -114,7 +114,7 @@ def wfs_25d_point(omega, x0, n0, xs, xref=[0, 0, 0], c=None, omalias=None):
         :context: close-figs
 
         d = sfs.mono.drivingfunction.wfs_25d_point(omega, x0, n0, xs)
-        a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
+        a = sfs.util.source_selection_point(n0, x0, xs)
         plot(d, a)
 
     """
@@ -150,7 +150,7 @@ def _wfs_plane(omega, x0, n0, n=[0, 1, 0], c=None):
         :context: close-figs
 
         d = sfs.mono.drivingfunction.wfs_3d_plane(omega, x0, n0, npw)
-        a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+        a = sfs.util.source_selection_plane(n0, npw)
         plot(d, a)
 
     """
@@ -180,7 +180,7 @@ def wfs_25d_plane(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None,
         :context: close-figs
 
         d = sfs.mono.drivingfunction.wfs_25d_plane(omega, x0, n0, npw)
-        a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+        a = sfs.util.source_selection_plane(n0, npw)
         plot(d, a)
 
     """
@@ -212,7 +212,7 @@ def _wfs_focused(omega, x0, n0, xs, c=None):
         :context: close-figs
 
         d = sfs.mono.drivingfunction.wfs_3d_focused(omega, x0, n0, xs_focused)
-        a = sfs.mono.drivingfunction.source_selection_focused(ns, x0, xs_focused)
+        a = sfs.util.source_selection_focused(ns, x0, xs_focused)
         plot(d, a)
 
     """
@@ -244,7 +244,7 @@ def wfs_25d_focused(omega, x0, n0, xs, xref=[0, 0, 0], c=None, omalias=None):
         :context: close-figs
 
         d = sfs.mono.drivingfunction.wfs_25d_focused(omega, x0, n0, xs_focused)
-        a = sfs.mono.drivingfunction.source_selection_focused(ns, x0, xs_focused)
+        a = sfs.util.source_selection_focused(ns, x0, xs_focused)
         plot(d, a)
 
     """
@@ -281,57 +281,6 @@ def delay_3d_plane(omega, x0, n0, n=[0, 1, 0], c=None):
     n = util.normalize_vector(n)
     k = util.wavenumber(omega, c)
     return np.exp(-1j * k * np.inner(n, x0))
-
-
-def source_selection_plane(n0, n):
-    """Secondary source selection for a plane wave.
-
-    Eq.(13) from :cite:`Spors2008`
-
-    """
-    n0 = util.asarray_of_rows(n0)
-    n = util.normalize_vector(n)
-    return np.inner(n, n0) >= default.selection_tolerance
-
-
-def source_selection_point(n0, x0, xs):
-    """Secondary source selection for a point source.
-
-    Eq.(15) from :cite:`Spors2008`
-
-    """
-    n0 = util.asarray_of_rows(n0)
-    x0 = util.asarray_of_rows(x0)
-    xs = util.asarray_1d(xs)
-    ds = x0 - xs
-    return inner1d(ds, n0) >= default.selection_tolerance
-
-
-def source_selection_line(n0, x0, xs):
-    """Secondary source selection for a line source.
-
-    compare Eq.(15) from :cite:`Spors2008`
-
-    """
-    return source_selection_point(n0, x0, xs)
-
-
-def source_selection_focused(ns, x0, xs):
-    """Secondary source selection for a focused source.
-
-    Eq.(2.78) from :cite:`Wierstorf2014`
-
-    """
-    x0 = util.asarray_of_rows(x0)
-    xs = util.asarray_1d(xs)
-    ns = util.normalize_vector(ns)
-    ds = xs - x0
-    return inner1d(ns, ds) >= default.selection_tolerance
-
-
-def source_selection_all(N):
-    """Select all secondary sources."""
-    return np.ones(N, dtype=bool)
 
 
 def nfchoa_2d_plane(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):

--- a/sfs/mono/soundfigure.py
+++ b/sfs/mono/soundfigure.py
@@ -39,7 +39,7 @@ def wfs_3d_pw(omega, x0, n0, figure, npw=[0, 0, 1], c=None):
                 npw = 1/k * np.asarray([kx[n], ky[m], kz])
                 npw = npw / np.linalg.norm(npw)
                 # driving function of plane wave with positive kz
-                a = drivingfunction.source_selection_plane(n0, npw)
+                a = util.source_selection_plane(n0, npw)
                 a = a * figure[n, m]
                 d += a * drivingfunction.wfs_3d_plane(omega, x0, n0, npw, c)
 

--- a/sfs/time/drivingfunction.py
+++ b/sfs/time/drivingfunction.py
@@ -98,7 +98,7 @@ def wfs_25d_plane(x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
 
         delays, weights = sfs.time.drivingfunction.wfs_25d_plane(x0, n0, npw)
         d = sfs.time.drivingfunction.driving_signals(delays, weights, signal)
-        a = sfs.mono.drivingfunction.source_selection_plane(n0, npw)
+        a = sfs.util.source_selection_plane(n0, npw)
         plot(d, a)
 
     """
@@ -168,7 +168,7 @@ def wfs_25d_point(x0, n0, xs, xref=[0, 0, 0], c=None):
 
         delays, weights = sfs.time.drivingfunction.wfs_25d_point(x0, n0, xs)
         d = sfs.time.drivingfunction.driving_signals(delays, weights, signal)
-        a = sfs.mono.drivingfunction.source_selection_point(n0, x0, xs)
+        a = sfs.util.source_selection_point(n0, x0, xs)
         plot(d, a, t=ts)
 
     """
@@ -241,7 +241,7 @@ def wfs_25d_focused(x0, n0, xs, xref=[0, 0, 0], c=None):
 
         delays, weights = sfs.time.drivingfunction.wfs_25d_focused(x0, n0, xf)
         d = sfs.time.drivingfunction.driving_signals(delays, weights, signal)
-        a = sfs.mono.drivingfunction.source_selection_focused(nf, x0, xf)
+        a = sfs.util.source_selection_focused(nf, x0, xf)
         plot(d, a, t=tf)
 
     """

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -6,6 +6,7 @@
 
 import collections
 import numpy as np
+from numpy.core.umath_tests import inner1d
 from scipy.special import spherical_jn, spherical_yn
 from . import default
 
@@ -564,3 +565,54 @@ def spherical_hn2(n, z):
 
     """
     return spherical_jn(n, z) - 1j * spherical_yn(n, z)
+
+
+def source_selection_plane(n0, n):
+    """Secondary source selection for a plane wave.
+
+    Eq.(13) from :cite:`Spors2008`
+
+    """
+    n0 = asarray_of_rows(n0)
+    n = normalize_vector(n)
+    return np.inner(n, n0) >= default.selection_tolerance
+
+
+def source_selection_point(n0, x0, xs):
+    """Secondary source selection for a point source.
+
+    Eq.(15) from :cite:`Spors2008`
+
+    """
+    n0 = asarray_of_rows(n0)
+    x0 = asarray_of_rows(x0)
+    xs = asarray_1d(xs)
+    ds = x0 - xs
+    return inner1d(ds, n0) >= default.selection_tolerance
+
+
+def source_selection_line(n0, x0, xs):
+    """Secondary source selection for a line source.
+
+    compare Eq.(15) from :cite:`Spors2008`
+
+    """
+    return source_selection_point(n0, x0, xs)
+
+
+def source_selection_focused(ns, x0, xs):
+    """Secondary source selection for a focused source.
+
+    Eq.(2.78) from :cite:`Wierstorf2014`
+
+    """
+    x0 = asarray_of_rows(x0)
+    xs = asarray_1d(xs)
+    ns = normalize_vector(ns)
+    ds = xs - x0
+    return inner1d(ns, ds) >= default.selection_tolerance
+
+
+def source_selection_all(N):
+    """Select all secondary sources."""
+    return np.ones(N, dtype=bool)


### PR DESCRIPTION
They are not specific to monochromatic applications, as @chris-hld already mentioned in https://github.com/sfstoolbox/sfs-python/issues/25#issuecomment-266313599.

I didn't know any better place than `sfs.util`, but if somebody else does, please speak up!