### PR TITLE
Cart2sph update

### DIFF
--- a/sfs/util.py
+++ b/sfs/util.py
@@ -102,7 +102,7 @@ def cart2sph(x, y, z):
         \beta = \arccos \left( \frac{z}{r} \right) \\
         r = \sqrt{x^2 + y^2 + z^2}
 
-    with :math:`\alpha \in [0, 2\pi), \beta \in [0, \pi], r \geq 0`
+    with :math:`\alpha \in [-pi, pi], \beta \in [0, \pi], r \geq 0`
 
     Parameters
     ----------

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -72,7 +72,7 @@ def sph2cart(alpha, beta, r):
     alpha : float or array_like
             Azimuth angle in radiants
     beta : float or array_like
-            Elevation angle in radiants (with 0 denoting North pole)
+            Colatitude angle in radiants (with 0 denoting North pole)
     r : float or array_like
             Radius
 
@@ -118,7 +118,7 @@ def cart2sph(x, y, z):
     alpha : float or array_like
             Azimuth angle in radiants
     beta : float or array_like
-            Elevation angle in radiants (with 0 denoting North pole)
+            Colatitude angle in radiants (with 0 denoting North pole)
     r : float or array_like
             Radius
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,16 +3,16 @@ from numpy.testing import assert_allclose
 import pytest
 import sfs
 
+
 cart_sph_data = [
     ((1, 1, 1), (np.pi / 4, np.arccos(1 / np.sqrt(3)), np.sqrt(3))),
-    ((-1, 1, 1), (np.arctan2(1, -1), np.arccos(1 / np.sqrt(3)), np.sqrt(3))),
+    ((-1, 1, 1), (3 / 4 * np.pi, np.arccos(1 / np.sqrt(3)), np.sqrt(3))),
     ((1, -1, 1), (-np.pi / 4, np.arccos(1 / np.sqrt(3)), np.sqrt(3))),
-    ((-1, -1, 1), (np.arctan2(-1, -1), np.arccos(1 / np.sqrt(3)), np.sqrt(3))),
+    ((-1, -1, 1), (-3 / 4 * np.pi, np.arccos(1 / np.sqrt(3)), np.sqrt(3))),
     ((1, 1, -1), (np.pi / 4, np.arccos(-1 / np.sqrt(3)), np.sqrt(3))),
-    ((-1, 1, -1), (np.arctan2(1, -1), np.arccos(-1 / np.sqrt(3)), np.sqrt(3))),
+    ((-1, 1, -1), (3 / 4 * np.pi, np.arccos(-1 / np.sqrt(3)), np.sqrt(3))),
     ((1, -1, -1), (-np.pi / 4, np.arccos(-1 / np.sqrt(3)), np.sqrt(3))),
-    ((-1, -1, -1), (np.arctan2(-1, -1),
-                    np.arccos(-1 / np.sqrt(3)), np.sqrt(3))),
+    ((-1, -1, -1), (-3 / 4 * np.pi, np.arccos(-1 / np.sqrt(3)), np.sqrt(3))),
 ]
 
 


### PR DESCRIPTION
This PR contains three minor updates to the conversion of Cartesian to spherical coordinates and vice versa.
- Reflect the actual range of 'alpha' in the doc-string
- Rename 'Elevation' to 'Colatitude' in the doc-string 
- Update the test to pre-calculated values

Discussion in https://github.com/sfstoolbox/sfs-python/issues/59.