### PR TITLE
DOC: Update a few URIs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,6 +81,6 @@ New releases are made using the following steps:
 #. Check that the new release was built correctly on RTD_, delete the "stable"
    version and select the new release as default version
 
-.. _twine: https://pypi.python.org/pypi/twine
+.. _twine: https://pypi.org/project/twine/
 .. _add release notes: https://github.com/sfstoolbox/sfs-python/tags
 .. _RTD: http://readthedocs.org/projects/sfs-python/builds/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -74,7 +74,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
-    'matplotlib': ('http://matplotlib.org/', None),
+    'matplotlib': ('https://matplotlib.org/', None),
 }
 
 plot_include_source = True

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -546,7 +546,7 @@ def image_sources_for_box(x, L, N, prune=True):
 def spherical_hn2(n, z):
     r"""Spherical Hankel function of 2nd kind.
 
-    Defined as http://dlmf.nist.gov/10.47.E6,
+    Defined as https://dlmf.nist.gov/10.47.E6,
 
     .. math::
 


### PR DESCRIPTION
Broken/outdated links can be found with

    python3 setup.py build_sphinx -b linkcheck

I did *not* update the SFS-Toolbox equation links, because those are still in flux, see #103.