### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[bdist_wheel]
-universal=1
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
We don't need "universal" wheels anymore since we dropped Python 2 support.

But we should include `LICENSE` in the wheel.