### PR TITLE
WFS 2.5D point source

### DIFF
--- a/doc/references.bib
+++ b/doc/references.bib
@@ -70,3 +70,29 @@
     year = {1984},
     doi = {10.1121/1.390983}
 }
+@article{Firtha2017,
+    author = {Gergely Firtha AND P{\'e}ter Fiala AND Frank Schultz AND
+        Sascha Spors},
+    title = {{Improved Referencing Schemes for 2.5D Wave Field Synthesis
+        Driving Functions}},
+    journal = {IEEE/ACM Trans. Audio Speech Language Process.},
+    volume = {25},
+    number = {5},
+    pages = {1117-1127},
+    year = {2017},
+    doi = {10.1109/TASLP.2017.2689245}
+}
+@phdthesis{Start1997,
+  author = {Evert W. Start},
+  title = {{Direct Sound Enhancement by Wave Field Synthesis}},
+  school =  {Delft University of Technology},
+  year = {1997}
+}
+@phdthesis{Schultz2016,
+    author = {Frank Schultz},
+    title = {{Sound Field Synthesis for Line Source Array Applications in
+        Large-Scale Sound Reinforcement}},
+    school = {University of Rostock},
+    year = {2016},
+    doi = {10.18453/rosdok_id00001765}
+}


### PR DESCRIPTION
I remember we had this discussion a while ago in the Matlab toolbox. I try it here again :-)
I'd vote to change our default WFS 2.5D point source to that driving function originating from Delft, which is compatible with the recent works of Firtha, i.e. the [unified WFS framework](https://github.com/gfirtha/gfirtha_phd_thesis).
Our currently used version is -- due to the further approximation -- not easy to handle in terms of
- consistent and proper amplitude normalization
- introducing/defining other referencing schemes

The PR is merge prepared in terms of our latest changes w.r.t. driving function and docstring example handling, but not for literature references.

I would not mind to supply both driving functions with a consistent and proper name scheme. I did not come up with a meaningful idea, though.
 