### PR TITLE
DOC: Install ffmpeg on RTD

### DIFF
--- a/doc/readthedocs-environment.yml
+++ b/doc/readthedocs-environment.yml
@@ -1,11 +1,9 @@
 channels:
   - cdat-forge
-  - conda-forge
 dependencies:
   - python>=3
   - sphinx>=1.3.6
   - sphinx_rtd_theme
-  - sphinxcontrib-bibtex
   - numpy
   - scipy
   - matplotlib>=1.5
@@ -14,3 +12,4 @@ dependencies:
   - ffmpeg
   - pip:
     - nbsphinx
+    - sphinxcontrib-bibtex

--- a/doc/readthedocs-environment.yml
+++ b/doc/readthedocs-environment.yml
@@ -4,10 +4,10 @@ dependencies:
   - sphinx_rtd_theme
   - numpy
   - scipy
+  - matplotlib==2.2.*
   - ipykernel
   - pandoc
   - ffmpeg
   - pip:
-    - matplotlib>=1.5
     - nbsphinx
     - sphinxcontrib-bibtex

--- a/doc/readthedocs-environment.yml
+++ b/doc/readthedocs-environment.yml
@@ -10,5 +10,6 @@ dependencies:
   - matplotlib>=1.5
   - ipykernel
   - pandoc
+  - ffmpeg
   - pip:
     - nbsphinx

--- a/doc/readthedocs-environment.yml
+++ b/doc/readthedocs-environment.yml
@@ -1,3 +1,5 @@
+channels:
+  - conda-forge
 dependencies:
   - python>=3
   - sphinx>=1.3.6

--- a/doc/readthedocs-environment.yml
+++ b/doc/readthedocs-environment.yml
@@ -1,5 +1,3 @@
-channels:
-  - cdat-forge
 dependencies:
   - python>=3
   - sphinx>=1.3.6

--- a/doc/readthedocs-environment.yml
+++ b/doc/readthedocs-environment.yml
@@ -1,4 +1,5 @@
 channels:
+  - cdat-forge
   - conda-forge
 dependencies:
   - python>=3

--- a/doc/readthedocs-environment.yml
+++ b/doc/readthedocs-environment.yml
@@ -1,15 +1,13 @@
-channels:
-  - conda-forge
 dependencies:
   - python>=3
   - sphinx>=1.3.6
   - sphinx_rtd_theme
   - numpy
   - scipy
-  - matplotlib>=1.5
   - ipykernel
   - pandoc
   - ffmpeg
   - pip:
+    - matplotlib>=1.5
     - nbsphinx
     - sphinxcontrib-bibtex


### PR DESCRIPTION
This doesn't seem to be installed by default but we need it for
generating animations.

**This does not work on RTD yet!**

For some reason, this seems to time out (after about 200 seconds) after generating this output (see https://readthedocs.org/projects/sfs-python/builds/8744378/):

```
conda env create --quiet --name ffmpeg --file /home/docs/checkouts/readthedocs.org/user_builds/sfs-python/checkouts/ffmpeg/doc/readthedocs-environment.yml
Solving environment: ...working... done
Preparing transaction: ...working... done
Verifying transaction: ...working... 
```

Any ideas what's going wrong there?