### PR TITLE
DOC: use \mathtt{} for "max_order"

### DIFF
--- a/sfs/util.py
+++ b/sfs/util.py
@@ -625,7 +625,7 @@ def max_order_circular_harmonics(N):
     It is given on page 132 of [Ahrens2012]_ as
 
     .. math::
-        \text{max\_order} =
+        \mathtt{max\_order} =
             \begin{cases}
                 N/2 - 1 & \text{even}\;N \\
                 (N-1)/2 & \text{odd}\;N,
@@ -634,7 +634,7 @@ def max_order_circular_harmonics(N):
     which is equivalent to
 
     .. math::
-        \text{max\_order} = \big\lfloor \frac{N - 1}{2} \big\rfloor.
+        \mathtt{max\_order} = \big\lfloor \frac{N - 1}{2} \big\rfloor.
 
     Parameters
     ----------
@@ -649,7 +649,7 @@ def max_order_spherical_harmonics(N):
     r"""Maximum order of 3D HOA.
 
     .. math::
-        \text{max\_order} = \lfloor \sqrt{N} \rfloor - 1.
+        \mathtt{max\_order} = \lfloor \sqrt{N} \rfloor - 1.
 
     Parameters
     ----------


### PR DESCRIPTION
It turns out that #110 fixed the LaTeX output, but it broke the MathJax output.

This PR should work for both.

If you don't like this, we could also use something like `M` or `M_\text{max}` as symbol for the maximum order.

Any preferences?