### PR TITLE
Allow "import sfs.time as sfs"

### DIFF
--- a/doc/examples/animations_pulsating_sphere.py
+++ b/doc/examples/animations_pulsating_sphere.py
@@ -1,5 +1,5 @@
 """Animations of pulsating sphere."""
-import sfs
+import sfs.mono as sfs
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib import animation
@@ -8,7 +8,7 @@ from matplotlib import animation
 def particle_displacement(omega, center, radius, amplitude, grid, frames,
                           figsize=(8, 8), interval=80, blit=True, **kwargs):
     """Generate sound particle animation."""
-    velocity = sfs.mono.source.pulsating_sphere_velocity(
+    velocity = sfs.source.pulsating_sphere_velocity(
                omega, center, radius, amplitude, grid)
     displacement = sfs.util.displacement(velocity, omega)
     phasor = np.exp(1j * 2 * np.pi / frames)
@@ -32,7 +32,7 @@ def particle_displacement(omega, center, radius, amplitude, grid, frames,
 def particle_velocity(omega, center, radius, amplitude, grid, frames,
                       figsize=(8, 8), interval=80, blit=True, **kwargs):
     """Generate particle velocity animation."""
-    velocity = sfs.mono.source.pulsating_sphere_velocity(
+    velocity = sfs.source.pulsating_sphere_velocity(
                omega, center, radius, amplitude, grid)
     phasor = np.exp(1j * 2 * np.pi / frames)
 
@@ -54,7 +54,7 @@ def sound_pressure(omega, center, radius, amplitude, grid, frames,
                    pulsate=False, figsize=(8, 8), interval=80, blit=True,
                    **kwargs):
     """Generate sound pressure animation."""
-    pressure = sfs.mono.source.pulsating_sphere(
+    pressure = sfs.source.pulsating_sphere(
             omega, center, radius, amplitude, grid, inside=pulsate)
     phasor = np.exp(1j * 2 * np.pi / frames)
 

--- a/doc/examples/horizontal_plane_arrays.py
+++ b/doc/examples/horizontal_plane_arrays.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-import sfs
+import sfs.mono as sfs
 
 
 dx = 0.1  # secondary source distance
@@ -30,7 +30,7 @@ def compute_and_plot_soundfield(title):
     print('Computing', title)
 
     twin = tapering(selection, talpha)
-    p = sfs.mono.synthesize(d, twin, array, secondary_source, grid=grid)
+    p = sfs.synthesize(d, twin, array, secondary_source, grid=grid)
 
     plt.figure(figsize=(15, 15))
     plt.cla()
@@ -46,34 +46,34 @@ def compute_and_plot_soundfield(title):
 # linear array, secondary point sources, virtual monopole
 array = sfs.array.linear(N, dx, center=acenter, orientation=anormal)
 
-d, selection, secondary_source = sfs.mono.wfs.point_3d(
+d, selection, secondary_source = sfs.wfs.point_3d(
     omega, array.x, array.n, xs)
 compute_and_plot_soundfield('linear_ps_wfs_3d_point')
 
-d, selection, secondary_source = sfs.mono.wfs.point_25d(
+d, selection, secondary_source = sfs.wfs.point_25d(
     omega, array.x, array.n, xs, xref=xnorm)
 compute_and_plot_soundfield('linear_ps_wfs_25d_point')
 
-d, selection, secondary_source = sfs.mono.wfs.point_2d(
+d, selection, secondary_source = sfs.wfs.point_2d(
     omega, array.x, array.n, xs)
 compute_and_plot_soundfield('linear_ps_wfs_2d_point')
 
 # linear array, secondary line sources, virtual line source
-d, selection, secondary_source = sfs.mono.wfs.line_2d(
+d, selection, secondary_source = sfs.wfs.line_2d(
     omega, array.x, array.n, xs)
 compute_and_plot_soundfield('linear_ls_wfs_2d_line')
 
 
 # linear array, secondary point sources, virtual plane wave
-d, selection, secondary_source = sfs.mono.wfs.plane_3d(
+d, selection, secondary_source = sfs.wfs.plane_3d(
     omega, array.x, array.n, npw)
 compute_and_plot_soundfield('linear_ps_wfs_3d_plane')
 
-d, selection, secondary_source = sfs.mono.wfs.plane_25d(
+d, selection, secondary_source = sfs.wfs.plane_25d(
     omega, array.x, array.n, npw, xref=xnorm)
 compute_and_plot_soundfield('linear_ps_wfs_25d_plane')
 
-d, selection, secondary_source = sfs.mono.wfs.plane_2d(
+d, selection, secondary_source = sfs.wfs.plane_2d(
     omega, array.x, array.n, npw)
 compute_and_plot_soundfield('linear_ps_wfs_2d_plane')
 
@@ -82,11 +82,11 @@ compute_and_plot_soundfield('linear_ps_wfs_2d_plane')
 array = sfs.array.linear_diff(N//3 * [dx] + N//3 * [dx/2] + N//3 * [dx],
                                    center=acenter, orientation=anormal)
 
-d, selection, secondary_source = sfs.mono.wfs.point_25d(
+d, selection, secondary_source = sfs.wfs.point_25d(
     omega, array.x, array.n, xs, xref=xnorm)
 compute_and_plot_soundfield('linear_nested_ps_wfs_25d_point')
 
-d, selection, secondary_source = sfs.mono.wfs.plane_25d(
+d, selection, secondary_source = sfs.wfs.plane_25d(
     omega, array.x, array.n, npw, xref=xnorm)
 compute_and_plot_soundfield('linear_nested_ps_wfs_25d_plane')
 
@@ -95,22 +95,22 @@ compute_and_plot_soundfield('linear_nested_ps_wfs_25d_plane')
 array = sfs.array.linear_random(N, dx/2, 1.5*dx, center=acenter,
                                      orientation=anormal)
 
-d, selection, secondary_source = sfs.mono.wfs.point_25d(
+d, selection, secondary_source = sfs.wfs.point_25d(
     omega, array.x, array.n, xs, xref=xnorm)
 compute_and_plot_soundfield('linear_random_ps_wfs_25d_point')
 
-d, selection, secondary_source = sfs.mono.wfs.plane_25d(
+d, selection, secondary_source = sfs.wfs.plane_25d(
     omega, array.x, array.n, npw, xref=xnorm)
 compute_and_plot_soundfield('linear_random_ps_wfs_25d_plane')
 
 
 # rectangular array, secondary point sources
 array = sfs.array.rectangular((N, N//2), dx, center=acenter, orientation=anormal)
-d, selection, secondary_source = sfs.mono.wfs.point_25d(
+d, selection, secondary_source = sfs.wfs.point_25d(
     omega, array.x, array.n, xs, xref=xnorm)
 compute_and_plot_soundfield('rectangular_ps_wfs_25d_point')
 
-d, selection, secondary_source = sfs.mono.wfs.plane_25d(
+d, selection, secondary_source = sfs.wfs.plane_25d(
     omega, array.x, array.n, npw, xref=xnorm)
 compute_and_plot_soundfield('rectangular_ps_wfs_25d_plane')
 
@@ -118,11 +118,11 @@ compute_and_plot_soundfield('rectangular_ps_wfs_25d_plane')
 # circular array, secondary point sources
 N = 60
 array = sfs.array.circular(N, 1, center=acenter)
-d, selection, secondary_source = sfs.mono.wfs.point_25d(
+d, selection, secondary_source = sfs.wfs.point_25d(
     omega, array.x, array.n, xs, xref=xnorm)
 compute_and_plot_soundfield('circular_ps_wfs_25d_point')
 
-d, selection, secondary_source = sfs.mono.wfs.plane_25d(
+d, selection, secondary_source = sfs.wfs.plane_25d(
     omega, array.x, array.n, npw, xref=xnorm)
 compute_and_plot_soundfield('circular_ps_wfs_25d_plane')
 
@@ -132,7 +132,7 @@ array = sfs.array.circular(N, 1)
 xnorm = [0, 0, 0]
 talpha = 0  # switches off tapering
 
-d, selection, secondary_source = sfs.mono.nfchoa.plane_2d(
+d, selection, secondary_source = sfs.nfchoa.plane_2d(
     omega, array.x, 1, npw)
 compute_and_plot_soundfield('circular_ls_nfchoa_2d_plane')
 
@@ -142,10 +142,10 @@ array = sfs.array.circular(N, 1)
 xnorm = [0, 0, 0]
 talpha = 0  # switches off tapering
 
-d, selection, secondary_source = sfs.mono.nfchoa.point_25d(
+d, selection, secondary_source = sfs.nfchoa.point_25d(
     omega, array.x, 1, xs)
 compute_and_plot_soundfield('circular_ps_nfchoa_25d_point')
 
-d, selection, secondary_source = sfs.mono.nfchoa.plane_25d(
+d, selection, secondary_source = sfs.nfchoa.plane_25d(
     omega, array.x, 1, npw)
 compute_and_plot_soundfield('circular_ps_nfchoa_25d_plane')

--- a/doc/examples/modal-room-acoustics.ipynb
+++ b/doc/examples/modal-room-acoustics.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import sfs"
+    "import sfs.mono as sfs"
    ]
   },
   {
@@ -87,7 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "p = sfs.mono.source.point_modal(omega, x0, grid, L, N=N, deltan=deltan)"
+    "p = sfs.source.point_modal(omega, x0, grid, L, N=N, deltan=deltan)"
    ]
   },
   {
@@ -135,7 +135,7 @@
     "\n",
     "receiver = 1, 1, 1.8\n",
     "\n",
-    "p = [sfs.mono.source.point_modal(om, x0, receiver, L, N=N, deltan=deltan)\n",
+    "p = [sfs.source.point_modal(om, x0, receiver, L, N=N, deltan=deltan)\n",
     "     for om in omega]\n",
     "     \n",
     "plt.plot(f, sfs.util.db(p))\n",

--- a/doc/examples/plot_particle_density.py
+++ b/doc/examples/plot_particle_density.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-import sfs
+import sfs.mono as sfs
 
 # simulation parameters
 pw_angle = 45  # traveling direction of plane wave
@@ -31,16 +31,16 @@ def plot_particle_displacement(title):
 
 
 # point source
-v = sfs.mono.source.point_velocity(omega, xs, grid)
+v = sfs.source.point_velocity(omega, xs, grid)
 amplitude = 1.5e6
 plot_particle_displacement('particle_displacement_point_source')
 
 # line source
-v = sfs.mono.source.line_velocity(omega, xs, grid)
+v = sfs.source.line_velocity(omega, xs, grid)
 amplitude = 1.3e6
 plot_particle_displacement('particle_displacement_line_source')
 
 # plane wave
-v = sfs.mono.source.plane_velocity(omega, xs, npw, grid)
+v = sfs.source.plane_velocity(omega, xs, npw, grid)
 amplitude = 1e5
 plot_particle_displacement('particle_displacement_plane_wave')

--- a/doc/examples/sound_field_synthesis.py
+++ b/doc/examples/sound_field_synthesis.py
@@ -8,7 +8,7 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-import sfs
+import sfs.mono as sfs
 
 
 # simulation parameters
@@ -44,22 +44,22 @@ array = sfs.array.circular(N, R)
 
 
 # === compute driving function and determine active secondary sources ===
-#d, selection, secondary_source = sfs.mono.wfs.plane_3d_delay(omega, array.x, array.n, npw)
+#d, selection, secondary_source = sfs.wfs.plane_3d_delay(omega, array.x, array.n, npw)
 
-#d, selection, secondary_source = sfs.mono.wfs.line_2d(omega, array.x, array.n, xs)
+#d, selection, secondary_source = sfs.wfs.line_2d(omega, array.x, array.n, xs)
 
-#d, selection, secondary_source = sfs.mono.wfs.plane_2d(omega, array.x, array.n, npw)
-d, selection, secondary_source = sfs.mono.wfs.plane_25d(omega, array.x, array.n, npw, xref)
-#d, selection, secondary_source = sfs.mono.wfs.plane_3d(omega, array.x, array.n, npw)
+#d, selection, secondary_source = sfs.wfs.plane_2d(omega, array.x, array.n, npw)
+d, selection, secondary_source = sfs.wfs.plane_25d(omega, array.x, array.n, npw, xref)
+#d, selection, secondary_source = sfs.wfs.plane_3d(omega, array.x, array.n, npw)
 
-#d, selection, secondary_source = sfs.mono.wfs.point_2d(omega, array.x, array.n, xs)
-#d, selection, secondary_source = sfs.mono.wfs.point_25d(omega, array.x, array.n, xs)
-#d, selection, secondary_source = sfs.mono.wfs.point_3d(omega, array.x, array.n, xs)
+#d, selection, secondary_source = sfs.wfs.point_2d(omega, array.x, array.n, xs)
+#d, selection, secondary_source = sfs.wfs.point_25d(omega, array.x, array.n, xs)
+#d, selection, secondary_source = sfs.wfs.point_3d(omega, array.x, array.n, xs)
 
-#d, selection, secondary_source = sfs.mono.nfchoa.plane_2d(omega, array.x, R, npw)
+#d, selection, secondary_source = sfs.nfchoa.plane_2d(omega, array.x, R, npw)
 
-#d, selection, secondary_source = sfs.mono.nfchoa.point_25d(omega, array.x, R, xs)
-#d, selection, secondary_source = sfs.mono.nfchoa.plane_25d(omega, array.x, R, npw)
+#d, selection, secondary_source = sfs.nfchoa.point_25d(omega, array.x, R, xs)
+#d, selection, secondary_source = sfs.nfchoa.plane_25d(omega, array.x, R, npw)
 
 
 # === compute tapering window ===
@@ -68,7 +68,7 @@ d, selection, secondary_source = sfs.mono.wfs.plane_25d(omega, array.x, array.n,
 twin = sfs.tapering.tukey(selection, 0.3)
 
 # === compute synthesized sound field ===
-p = sfs.mono.synthesize(d, twin, array, secondary_source, grid=grid)
+p = sfs.synthesize(d, twin, array, secondary_source, grid=grid)
 
 
 # === plot synthesized sound field ===

--- a/doc/examples/soundfigures.py
+++ b/doc/examples/soundfigures.py
@@ -7,7 +7,7 @@ images are located in the "figures/" directory.
 import numpy as np
 import matplotlib.pyplot as plt
 from PIL import Image
-import sfs
+import sfs.mono as sfs
 
 dx = 0.10  # secondary source distance
 N = 60  # number of secondary sources
@@ -29,11 +29,11 @@ array = sfs.array.cube(N, dx)
 # driving function for sound figure
 figure = np.array(Image.open('figures/tree.png'))  # read image from file
 figure = np.rot90(figure)  # turn 0deg to the top
-d, selection, secondary_source = sfs.mono.wfs.soundfigure_3d(
+d, selection, secondary_source = sfs.wfs.soundfigure_3d(
     omega, array.x, array.n, figure, npw=npw)
 
 # compute synthesized sound field
-p = sfs.mono.synthesize(d, selection, array, secondary_source, grid=grid)
+p = sfs.synthesize(d, selection, array, secondary_source, grid=grid)
 
 # plot and save synthesized sound field
 plt.figure(figsize=(10, 10))

--- a/doc/examples/time_domain.py
+++ b/doc/examples/time_domain.py
@@ -7,7 +7,7 @@ Simulate and plot impulse behavior for Wave Field Synthesis.
 
 import numpy as np
 import matplotlib.pyplot as plt
-import sfs
+import sfs.time as sfs
 
 # simulation parameters
 grid = sfs.util.xyz_grid([-3, 3], [-3, 3], 0, spacing=0.01)
@@ -24,15 +24,15 @@ signal = [1], fs
 xs = 2, 2, 0  # position of virtual source
 t = 0.008
 # compute driving signals
-d_delay, d_weight, selection, secondary_source = \
-    sfs.time.wfs.point_25d(array.x, array.n, xs)
-d = sfs.time.wfs.driving_signals(d_delay, d_weight, signal)
+d_delay, d_weight, selection, secondary_source = sfs.wfs.point_25d(
+    array.x, array.n, xs)
+d = sfs.wfs.driving_signals(d_delay, d_weight, signal)
 
 # test soundfield
 twin = sfs.tapering.tukey(selection, .3)
 
-p = sfs.time.synthesize(d, twin, array,
-                        secondary_source, observation_time=t, grid=grid)
+p = sfs.synthesize(d, twin, array,
+                   secondary_source, observation_time=t, grid=grid)
 p = p * 100  # scale absolute amplitude
 
 plt.figure(figsize=(10, 10))
@@ -49,14 +49,14 @@ npw = sfs.util.direction_vector(np.radians(pw_angle))
 t = -0.001
 
 # compute driving signals
-d_delay, d_weight, selection, secondary_source = \
-    sfs.time.wfs.plane_25d(array.x, array.n, npw)
-d = sfs.time.wfs.driving_signals(d_delay, d_weight, signal)
+d_delay, d_weight, selection, secondary_source = sfs.wfs.plane_25d(
+    array.x, array.n, npw)
+d = sfs.wfs.driving_signals(d_delay, d_weight, signal)
 
 # test soundfield
 twin = sfs.tapering.tukey(selection, .3)
-p = sfs.time.synthesize(d, twin, array,
-                        secondary_source, observation_time=t, grid=grid)
+p = sfs.synthesize(d, twin, array,
+                   secondary_source, observation_time=t, grid=grid)
 
 plt.figure(figsize=(10, 10))
 sfs.plot.level(p, grid, cmap=my_cmap)
@@ -71,14 +71,14 @@ xs = np.r_[0.5, 0.5, 0]  # position of virtual source
 xref = np.r_[0, 0, 0]
 nfs = sfs.util.normalize_vector(xref - xs)  # main n of fsource
 t = 0.003  # compute driving signals
-d_delay, d_weight, selection, secondary_source = \
-    sfs.time.wfs.focused_25d(array.x, array.n, xs, nfs)
-d = sfs.time.wfs.driving_signals(d_delay, d_weight, signal)
+d_delay, d_weight, selection, secondary_source = sfs.wfs.focused_25d(
+    array.x, array.n, xs, nfs)
+d = sfs.wfs.driving_signals(d_delay, d_weight, signal)
 
 # test soundfield
 twin = sfs.tapering.tukey(selection, .3)
-p = sfs.time.synthesize(d, twin, array,
-                        secondary_source, observation_time=t, grid=grid)
+p = sfs.synthesize(d, twin, array,
+                   secondary_source, observation_time=t, grid=grid)
 p = p * 100  # scale absolute amplitude
 
 plt.figure(figsize=(10, 10))

--- a/doc/examples/time_domain_nfchoa.py
+++ b/doc/examples/time_domain_nfchoa.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-import sfs
+import sfs.time as sfs
 from scipy.signal import unit_impulse
 
 # Parameters
@@ -20,11 +20,11 @@ max_order = None
 npw = [0, -1, 0]  # propagating direction
 t = 0  # observation time
 delay, weight, sos, phaseshift, selection, secondary_source = \
-    sfs.time.nfchoa.plane_25d(array.x, R, npw, fs, max_order)
-d = sfs.time.nfchoa.driving_signals_25d(
+    sfs.nfchoa.plane_25d(array.x, R, npw, fs, max_order)
+d = sfs.nfchoa.driving_signals_25d(
         delay, weight, sos, phaseshift, signal)
-p = sfs.time.synthesize(d, selection, array, secondary_source,
-                        observation_time=t, grid=grid)
+p = sfs.synthesize(d, selection, array, secondary_source,
+                   observation_time=t, grid=grid)
 
 plt.figure()
 sfs.plot.level(p, grid)
@@ -37,10 +37,10 @@ max_order = 100
 xs = [1.5, 1.5, 0]  # position
 t = np.linalg.norm(xs) / sfs.default.c  # observation time
 delay, weight, sos, phaseshift, selection, secondary_source = \
-    sfs.time.nfchoa.point_25d(array.x, R, xs, fs, max_order)
-d = sfs.time.nfchoa.driving_signals_25d(
+    sfs.nfchoa.point_25d(array.x, R, xs, fs, max_order)
+d = sfs.nfchoa.driving_signals_25d(
         delay, weight, sos, phaseshift, signal)
-p = sfs.time.synthesize(d, selection, array, secondary_source,
+p = sfs.synthesize(d, selection, array, secondary_source,
                         observation_time=t, grid=grid)
 
 plt.figure()

--- a/sfs/__init__.py
+++ b/sfs/__init__.py
@@ -55,8 +55,8 @@ if not getattr(_sys.modules.get('sphinx'), 'SFS_DOCS_ARE_BEING_BUILT', False):
     # This object shadows the 'default' class, except when the docs are built:
     default = default()
 
-from . import tapering
 from . import array
+from . import tapering
 from . import util
 try:
     from . import plot

--- a/sfs/mono/__init__.py
+++ b/sfs/mono/__init__.py
@@ -11,9 +11,9 @@
     esa
 
 """
-from . import source
-from .. import array as _array
 import numpy as _np
+from . import source
+from .. import array
 
 
 def shiftphase(p, phase):
@@ -48,7 +48,7 @@ def synthesize(d, weights, ssd, secondary_source_function, **kwargs):
         This is typically used to pass the *grid* argument.
 
     """
-    ssd = _array.as_secondary_source_distribution(ssd)
+    ssd = array.as_secondary_source_distribution(ssd)
     if not (len(ssd.x) == len(ssd.n) == len(ssd.a) == len(d) ==
             len(weights)):
         raise ValueError("length mismatch")
@@ -81,3 +81,11 @@ from . import esa
 from . import nfchoa
 from . import sdm
 from . import wfs
+
+from .. import default
+from .. import tapering
+from .. import util
+try:
+    from .. import plot
+except ImportError:
+    pass

--- a/sfs/time/__init__.py
+++ b/sfs/time/__init__.py
@@ -9,10 +9,10 @@
     nfchoa
 
 """
-from .. import array as _array
-import numpy as np
+import numpy as _np
 from . import source
-from .. import util as _util
+from .. import util
+from .. import array
 
 
 def synthesize(signals, weights, ssd, secondary_source_function, **kwargs):
@@ -50,9 +50,9 @@ def synthesize(signals, weights, ssd, secondary_source_function, **kwargs):
         Sound pressure at grid positions.
 
     """
-    ssd = _array.as_secondary_source_distribution(ssd)
-    data, samplerate, signal_offset = _util.as_delayed_signal(signals)
-    weights = _util.asarray_1d(weights)
+    ssd = array.as_secondary_source_distribution(ssd)
+    data, samplerate, signal_offset = util.as_delayed_signal(signals)
+    weights = util.asarray_1d(weights)
     channels = data.T
     if not (len(ssd.x) == len(ssd.n) == len(ssd.a) == len(channels) ==
             len(weights)):
@@ -85,18 +85,18 @@ def apply_delays(signal, delays):
         and a (possibly negative) time offset (in seconds).
 
     """
-    data, samplerate, initial_offset = _util.as_delayed_signal(signal)
-    data = _util.asarray_1d(data)
-    delays = _util.asarray_1d(delays)
+    data, samplerate, initial_offset = util.as_delayed_signal(signal)
+    data = util.asarray_1d(data)
+    delays = util.asarray_1d(delays)
     delays += initial_offset
 
-    delays_samples = np.rint(samplerate * delays).astype(int)
+    delays_samples = _np.rint(samplerate * delays).astype(int)
     offset_samples = delays_samples.min()
     delays_samples -= offset_samples
-    out = np.zeros((delays_samples.max() + len(data), len(delays_samples)))
+    out = _np.zeros((delays_samples.max() + len(data), len(delays_samples)))
     for column, row in enumerate(delays_samples):
         out[row:row + len(data), column] = data
-    return _util.DelayedSignal(out, samplerate, offset_samples / samplerate)
+    return util.DelayedSignal(out, samplerate, offset_samples / samplerate)
 
 
 def secondary_source_point(c):
@@ -110,3 +110,10 @@ def secondary_source_point(c):
 
 from . import nfchoa
 from . import wfs
+
+from .. import default
+from .. import tapering
+try:
+    from .. import plot
+except ImportError:
+    pass


### PR DESCRIPTION
I'm not sure if this is helpful or confusing, could be both ...

The idea is that *most of the time*, we want to use *either* time domain *or* frequency domain. There are much fewer cases where we want to use both in the same script/notebook (the "mirror image" notebook is an example for that).

To make it easier for the many cases, we could change the import a bit:

```python
import sfs.time as sfs
```

... and then we don't ever need to use `time` in the rest of the script/notebook anymore.

What do you think about this?
Is this silly?