### PR TITLE
Hide warnings for a few undefined points

### DIFF
--- a/sfs/fd/source.py
+++ b/sfs/fd/source.py
@@ -84,7 +84,7 @@ def point(omega, x0, grid, *, c=None):
     r = np.linalg.norm(grid - x0)
     # If r is 0, the sound pressure is complex infinity
     numerator = np.exp(-1j * k * r) / (4*np.pi)
-    with np.errstate(divide='ignore'):
+    with np.errstate(invalid='ignore', divide='ignore'):
         return numerator / r
 
 

--- a/sfs/fd/source.py
+++ b/sfs/fd/source.py
@@ -82,7 +82,9 @@ def point(omega, x0, grid, *, c=None):
     grid = util.as_xyz_components(grid)
 
     r = np.linalg.norm(grid - x0)
-    return 1 / (4*np.pi) * np.exp(-1j * k * r) / r
+    # `r` can get `0`, which is fine in this case
+    with np.errstate(invalid='ignore', divide='ignore'):
+        return 1 / (4*np.pi) * np.exp(-1j * k * r) / r
 
 
 def point_velocity(omega, x0, grid, *, c=None, rho0=None):
@@ -395,7 +397,9 @@ def point_image_sources(omega, x0, grid, L, *, max_order, coeffs=None, c=None):
     p = 0
     for position, strength in zip(xs, source_strengths):
         if strength != 0:
-            p += strength * point(omega, position, grid, c=c)
+            # `point` can return NaN, which is fine
+            with np.errstate(invalid='ignore'):
+                p += strength * point(omega, position, grid, c=c)
 
     return p
 

--- a/sfs/fd/source.py
+++ b/sfs/fd/source.py
@@ -82,9 +82,10 @@ def point(omega, x0, grid, *, c=None):
     grid = util.as_xyz_components(grid)
 
     r = np.linalg.norm(grid - x0)
-    # `r` can get `0`, which is fine in this case
-    with np.errstate(invalid='ignore', divide='ignore'):
-        return 1 / (4*np.pi) * np.exp(-1j * k * r) / r
+    # If r is 0, the sound pressure is complex infinity
+    numerator = np.exp(-1j * k * r) / (4*np.pi)
+    with np.errstate(divide='ignore'):
+        return numerator / r
 
 
 def point_velocity(omega, x0, grid, *, c=None, rho0=None):
@@ -397,7 +398,7 @@ def point_image_sources(omega, x0, grid, L, *, max_order, coeffs=None, c=None):
     p = 0
     for position, strength in zip(xs, source_strengths):
         if strength != 0:
-            # `point` can return NaN, which is fine
+            # point can be complex infinity
             with np.errstate(invalid='ignore'):
                 p += strength * point(omega, position, grid, c=c)
 

--- a/sfs/td/source.py
+++ b/sfs/td/source.py
@@ -79,16 +79,17 @@ def point(xs, signal, observation_time, grid, c=None):
     if c is None:
         c = default.c
     r = np.linalg.norm(grid - xs)
-    # evaluate g over grid (`r` can get `0`, which is fine)
+    # If r is +-0, the sound pressure is +-infinity
     with np.errstate(divide='ignore'):
         weights = 1 / (4 * np.pi * r)
     delays = r / c
     base_time = observation_time - signal_offset
-    # Result can be NaN, which is fine
+    points_at_time = np.interp(base_time - delays,
+                               np.arange(len(data)) / samplerate,
+                               data, left=0, right=0)
+    # weights can be +-infinity
     with np.errstate(invalid='ignore'):
-        return weights * np.interp(base_time - delays,
-                                   np.arange(len(data)) / samplerate,
-                                   data, left=0, right=0)
+        return weights * points_at_time
 
 
 def point_image_sources(x0, signal, observation_time, grid, L, max_order,

--- a/sfs/td/source.py
+++ b/sfs/td/source.py
@@ -79,13 +79,16 @@ def point(xs, signal, observation_time, grid, c=None):
     if c is None:
         c = default.c
     r = np.linalg.norm(grid - xs)
-    # evaluate g over grid
-    weights = 1 / (4 * np.pi * r)
+    # evaluate g over grid (`r` can get `0`, which is fine)
+    with np.errstate(divide='ignore'):
+        weights = 1 / (4 * np.pi * r)
     delays = r / c
     base_time = observation_time - signal_offset
-    return weights * np.interp(base_time - delays,
-                               np.arange(len(data)) / samplerate,
-                               data, left=0, right=0)
+    # Result can be NaN, which is fine
+    with np.errstate(invalid='ignore'):
+        return weights * np.interp(base_time - delays,
+                                   np.arange(len(data)) / samplerate,
+                                   data, left=0, right=0)
 
 
 def point_image_sources(x0, signal, observation_time, grid, L, max_order,


### PR DESCRIPTION
This suppresses the warnings mentioned in #107.

But I think the current solution is very ugly and covers only a few of the places where this can occur.
The problem is that a lot of our sources, e.g. a point source have some points where they are not defined and it is valid to have `NaN`, `Inf`, divide by zero or other stuff. But it will be a huge effort to find every line where this has to be fixed.

Another solution would be to generally allow for division by zero or multiplication by `NaN` in the whole toolbox, but this is also not nice.

Has somebody an idea how to better handle undefined points in numpy?