### PR TITLE
Keyword-only arguments everywhere

### DIFF
--- a/doc/examples/horizontal_plane_arrays.py
+++ b/doc/examples/horizontal_plane_arrays.py
@@ -29,12 +29,12 @@ def compute_and_plot_soundfield(title):
     """Compute and plot synthesized sound field."""
     print('Computing', title)
 
-    twin = tapering(selection, talpha)
+    twin = tapering(selection, alpha=talpha)
     p = sfs.fd.synthesize(d, twin, array, secondary_source, grid=grid)
 
     plt.figure(figsize=(15, 15))
     plt.cla()
-    sfs.plot2d.amplitude(p, grid, xnorm)
+    sfs.plot2d.amplitude(p, grid, xnorm=xnorm)
     sfs.plot2d.loudspeakers(array.x, array.n, twin)
     sfs.plot2d.virtualsource(xs)
     sfs.plot2d.virtualsource([0, 0], npw, type='plane')

--- a/doc/examples/mirror-image-source-model.ipynb
+++ b/doc/examples/mirror-image-source-model.ipynb
@@ -94,7 +94,7 @@
    "source": [
     "grid = sfs.util.xyz_grid([0, L[0]], [0, L[1]], 1.5, spacing=0.02)\n",
     "P = sfs.fd.source.point_image_sources(omega, x0, grid, L,\n",
-    "                                      max_order, coeffs=coeffs)"
+    "                                      max_order=max_order, coeffs=coeffs)"
    ]
   },
   {

--- a/doc/examples/sound_field_synthesis.py
+++ b/doc/examples/sound_field_synthesis.py
@@ -49,7 +49,7 @@ array = sfs.array.circular(N, R)
 #d, selection, secondary_source = sfs.fd.wfs.line_2d(omega, array.x, array.n, xs)
 
 #d, selection, secondary_source = sfs.fd.wfs.plane_2d(omega, array.x, array.n, npw)
-d, selection, secondary_source = sfs.fd.wfs.plane_25d(omega, array.x, array.n, npw, xref)
+d, selection, secondary_source = sfs.fd.wfs.plane_25d(omega, array.x, array.n, npw, xref=xref)
 #d, selection, secondary_source = sfs.fd.wfs.plane_3d(omega, array.x, array.n, npw)
 
 #d, selection, secondary_source = sfs.fd.wfs.point_2d(omega, array.x, array.n, xs)
@@ -64,8 +64,8 @@ d, selection, secondary_source = sfs.fd.wfs.plane_25d(omega, array.x, array.n, n
 
 # === compute tapering window ===
 #twin = sfs.tapering.none(selection)
-#twin = sfs.tapering.kaiser(selection, 8.6)
-twin = sfs.tapering.tukey(selection, 0.3)
+#twin = sfs.tapering.kaiser(selection, beta=8.6)
+twin = sfs.tapering.tukey(selection, alpha=0.3)
 
 # === compute synthesized sound field ===
 p = sfs.fd.synthesize(d, twin, array, secondary_source, grid=grid)
@@ -73,7 +73,7 @@ p = sfs.fd.synthesize(d, twin, array, secondary_source, grid=grid)
 
 # === plot synthesized sound field ===
 plt.figure(figsize=(10, 10))
-sfs.plot2d.amplitude(p, grid, [0, 0, 0])
+sfs.plot2d.amplitude(p, grid, xnorm=[0, 0, 0])
 sfs.plot2d.loudspeakers(array.x, array.n, twin)
 plt.grid()
 plt.savefig('soundfield.png')

--- a/doc/examples/time_domain.py
+++ b/doc/examples/time_domain.py
@@ -29,7 +29,7 @@ d_delay, d_weight, selection, secondary_source = \
 d = sfs.td.wfs.driving_signals(d_delay, d_weight, signal)
 
 # test soundfield
-twin = sfs.tapering.tukey(selection, .3)
+twin = sfs.tapering.tukey(selection, alpha=0.3)
 
 p = sfs.td.synthesize(d, twin, array,
                       secondary_source, observation_time=t, grid=grid)
@@ -54,7 +54,7 @@ d_delay, d_weight, selection, secondary_source = \
 d = sfs.td.wfs.driving_signals(d_delay, d_weight, signal)
 
 # test soundfield
-twin = sfs.tapering.tukey(selection, .3)
+twin = sfs.tapering.tukey(selection, alpha=0.3)
 p = sfs.td.synthesize(d, twin, array,
                       secondary_source, observation_time=t, grid=grid)
 
@@ -76,7 +76,7 @@ d_delay, d_weight, selection, secondary_source = \
 d = sfs.td.wfs.driving_signals(d_delay, d_weight, signal)
 
 # test soundfield
-twin = sfs.tapering.tukey(selection, .3)
+twin = sfs.tapering.tukey(selection, alpha=0.3)
 p = sfs.td.synthesize(d, twin, array,
                       secondary_source, observation_time=t, grid=grid)
 p = p * 100  # scale absolute amplitude

--- a/sfs/array.py
+++ b/sfs/array.py
@@ -84,7 +84,7 @@ def as_secondary_source_distribution(arg, **kwargs):
     return SecondarySourceDistribution(x, n, a)
 
 
-def linear(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
+def linear(N, spacing, *, center=[0, 0, 0], orientation=[1, 0, 0]):
     """Return linear, equidistantly sampled secondary source distribution.
 
     Parameters
@@ -119,7 +119,7 @@ def linear(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
     return _linear_helper(np.arange(N) * spacing, center, orientation)
 
 
-def linear_diff(distances, center=[0, 0, 0], orientation=[1, 0, 0]):
+def linear_diff(distances, *, center=[0, 0, 0], orientation=[1, 0, 0]):
     """Return linear secondary source distribution from a list of distances.
 
     Parameters
@@ -152,7 +152,7 @@ def linear_diff(distances, center=[0, 0, 0], orientation=[1, 0, 0]):
     return _linear_helper(ycoordinates, center, orientation)
 
 
-def linear_random(N, min_spacing, max_spacing, center=[0, 0, 0],
+def linear_random(N, min_spacing, max_spacing, *, center=[0, 0, 0],
                   orientation=[1, 0, 0], seed=None):
     """Return randomly sampled linear array.
 
@@ -190,10 +190,10 @@ def linear_random(N, min_spacing, max_spacing, center=[0, 0, 0],
     """
     r = np.random.RandomState(seed)
     distances = r.uniform(min_spacing, max_spacing, size=N-1)
-    return linear_diff(distances, center, orientation)
+    return linear_diff(distances, center=center, orientation=orientation)
 
 
-def circular(N, R, center=[0, 0, 0]):
+def circular(N, R, *, center=[0, 0, 0]):
     """Return circular secondary source distribution parallel to the xy-plane.
 
     Parameters
@@ -235,7 +235,7 @@ def circular(N, R, center=[0, 0, 0]):
     return SecondarySourceDistribution(positions, normals, weights)
 
 
-def rectangular(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
+def rectangular(N, spacing, *, center=[0, 0, 0], orientation=[1, 0, 0]):
     """Return rectangular secondary source distribution.
 
     Parameters
@@ -272,10 +272,14 @@ def rectangular(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
     offset1 = spacing * (N2 - 1) / 2 + spacing / np.sqrt(2)
     offset2 = spacing * (N1 - 1) / 2 + spacing / np.sqrt(2)
     positions, normals, weights = concatenate(
-        linear(N1, spacing, [-offset1, 0, 0], [1, 0, 0]),  # left
-        linear(N2, spacing, [0, offset2, 0], [0, -1, 0]),  # upper
-        linear(N1, spacing, [offset1, 0, 0], [-1, 0, 0]),  # right
-        linear(N2, spacing, [0, -offset2, 0], [0, 1, 0]),  # lower
+        # left
+        linear(N1, spacing, center=[-offset1, 0, 0], orientation=[1, 0, 0]),
+        # upper
+        linear(N2, spacing, center=[0, offset2, 0], orientation=[0, -1, 0]),
+        # right
+        linear(N1, spacing, center=[offset1, 0, 0], orientation=[-1, 0, 0]),
+        # lower
+        linear(N2, spacing, center=[0, -offset2, 0], orientation=[0, 1, 0]),
     )
     positions, normals = _rotate_array(positions, normals,
                                        [1, 0, 0], orientation)
@@ -283,7 +287,7 @@ def rectangular(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
     return SecondarySourceDistribution(positions, normals, weights)
 
 
-def rounded_edge(Nxy, Nr, dx, center=[0, 0, 0], orientation=[1, 0, 0]):
+def rounded_edge(Nxy, Nr, dx, *, center=[0, 0, 0], orientation=[1, 0, 0]):
     """Return SSD along the xy-axis with rounded edge at the origin.
 
     Parameters
@@ -357,7 +361,7 @@ def rounded_edge(Nxy, Nr, dx, center=[0, 0, 0], orientation=[1, 0, 0]):
     return SecondarySourceDistribution(positions, directions, weights)
 
 
-def edge(Nxy, dx, center=[0, 0, 0], orientation=[1, 0, 0]):
+def edge(Nxy, dx, *, center=[0, 0, 0], orientation=[1, 0, 0]):
     """Return SSD along the xy-axis with sharp edge at the origin.
 
     Parameters
@@ -409,7 +413,7 @@ def edge(Nxy, dx, center=[0, 0, 0], orientation=[1, 0, 0]):
     return SecondarySourceDistribution(positions, directions, weights)
 
 
-def planar(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
+def planar(N, spacing, *, center=[0, 0, 0], orientation=[1, 0, 0]):
     """Return planar secondary source distribtion.
 
     Parameters
@@ -460,7 +464,7 @@ def planar(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
     return SecondarySourceDistribution(positions, normals, weights)
 
 
-def cube(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
+def cube(N, spacing, *, center=[0, 0, 0], orientation=[1, 0, 0]):
     """Return cube-shaped secondary source distribtion.
 
     Parameters
@@ -496,16 +500,23 @@ def cube(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
 
     """
     N1, N2, N3 = (N, N, N) if np.isscalar(N) else N
-    offset1 = spacing * (N2 - 1) / 2 + spacing / np.sqrt(2)
-    offset2 = spacing * (N1 - 1) / 2 + spacing / np.sqrt(2)
-    offset3 = spacing * (N3 - 1) / 2 + spacing / np.sqrt(2)
+    d = spacing
+    offset1 = d * (N2 - 1) / 2 + d / np.sqrt(2)
+    offset2 = d * (N1 - 1) / 2 + d / np.sqrt(2)
+    offset3 = d * (N3 - 1) / 2 + d / np.sqrt(2)
     positions, directions, weights = concatenate(
-        planar((N1, N3), spacing, [-offset1, 0, 0], [1, 0, 0]),  # west
-        planar((N2, N3), spacing, [0, offset2, 0], [0, -1, 0]),  # north
-        planar((N1, N3), spacing, [offset1, 0, 0], [-1, 0, 0]),  # east
-        planar((N2, N3), spacing, [0, -offset2, 0], [0, 1, 0]),  # south
-        planar((N2, N1), spacing, [0, 0, -offset3], [0, 0, 1]),  # bottom
-        planar((N2, N1), spacing, [0, 0, offset3], [0, 0, -1]),  # top
+        # west
+        planar((N1, N3), d, center=[-offset1, 0, 0], orientation=[1, 0, 0]),
+        # north
+        planar((N2, N3), d, center=[0, offset2, 0], orientation=[0, -1, 0]),
+        # east
+        planar((N1, N3), d, center=[offset1, 0, 0], orientation=[-1, 0, 0]),
+        # south
+        planar((N2, N3), d, center=[0, -offset2, 0], orientation=[0, 1, 0]),
+        # bottom
+        planar((N2, N1), d, center=[0, 0, -offset3], orientation=[0, 0, 1]),
+        # top
+        planar((N2, N1), d, center=[0, 0, offset3], orientation=[0, 0, -1]),
     )
     positions, directions = _rotate_array(positions, directions,
                                           [1, 0, 0], orientation)
@@ -513,7 +524,7 @@ def cube(N, spacing, center=[0, 0, 0], orientation=[1, 0, 0]):
     return SecondarySourceDistribution(positions, directions, weights)
 
 
-def sphere_load(file, radius, center=[0, 0, 0]):
+def sphere_load(file, radius, *, center=[0, 0, 0]):
     """Load spherical secondary source distribution from file.
 
     ASCII Format (see MATLAB SFS Toolbox) with 4 numbers (3 for the cartesian
@@ -562,7 +573,7 @@ def sphere_load(file, radius, center=[0, 0, 0]):
     return SecondarySourceDistribution(positions, normals, weights)
 
 
-def load(file, center=[0, 0, 0], orientation=[1, 0, 0]):
+def load(file, *, center=[0, 0, 0], orientation=[1, 0, 0]):
     """Load secondary source distribution from file.
 
     Comma Separated Values (CSV) format with 7 values
@@ -615,7 +626,7 @@ def load(file, center=[0, 0, 0], orientation=[1, 0, 0]):
     return SecondarySourceDistribution(positions, normals, weights)
 
 
-def weights_midpoint(positions, closed):
+def weights_midpoint(positions, *, closed):
     """Calculate loudspeaker weights for a simply connected array.
 
     The weights are calculated according to the midpoint rule.

--- a/sfs/fd/__init__.py
+++ b/sfs/fd/__init__.py
@@ -63,7 +63,7 @@ def secondary_source_point(omega, c):
     """Create a point source for use in `sfs.fd.synthesize()`."""
 
     def secondary_source(position, _, grid):
-        return source.point(omega, position, grid, c)
+        return source.point(omega, position, grid, c=c)
 
     return secondary_source
 
@@ -72,7 +72,7 @@ def secondary_source_line(omega, c):
     """Create a line source for use in `sfs.fd.synthesize()`."""
 
     def secondary_source(position, _, grid):
-        return source.line(omega, position, grid, c)
+        return source.line(omega, position, grid, c=c)
 
     return secondary_source
 

--- a/sfs/fd/esa.py
+++ b/sfs/fd/esa.py
@@ -16,8 +16,7 @@ from .. import util
 from . import secondary_source_line, secondary_source_point
 
 
-def plane_2d_edge(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
-             c=None):
+def plane_2d_edge(omega, x0, n=[0, 1, 0], *, alpha=3/2*np.pi, Nc=None, c=None):
     r"""Driving function for 2-dimensional plane wave with edge ESA.
 
     Driving function for a virtual plane wave using the 2-dimensional ESA
@@ -87,8 +86,8 @@ def plane_2d_edge(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
     return 4*np.pi/alpha * d, selection, secondary_source_line(omega, c)
 
 
-def plane_2d_edge_dipole_ssd(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
-                             c=None):
+def plane_2d_edge_dipole_ssd(omega, x0, n=[0, 1, 0], *, alpha=3/2*np.pi,
+                             Nc=None, c=None):
     r"""Driving function for 2-dimensional plane wave with edge dipole ESA.
 
     Driving function for a virtual plane wave using the 2-dimensional ESA
@@ -155,7 +154,7 @@ def plane_2d_edge_dipole_ssd(omega, x0, n=[0, 1, 0], alpha=3/2*np.pi, Nc=None,
     return 4*np.pi/alpha * d
 
 
-def line_2d_edge(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
+def line_2d_edge(omega, x0, xs, *, alpha=3/2*np.pi, Nc=None, c=None):
     r"""Driving function for 2-dimensional line source with edge ESA.
 
     Driving function for a virtual line source using the 2-dimensional ESA
@@ -229,7 +228,8 @@ def line_2d_edge(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     return -1j*np.pi/alpha * d, selection, secondary_source_line(omega, c)
 
 
-def line_2d_edge_dipole_ssd(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
+def line_2d_edge_dipole_ssd(omega, x0, xs, *, alpha=3/2*np.pi, Nc=None,
+                            c=None):
     r"""Driving function for 2-dimensional line source with edge dipole ESA.
 
     Driving function for a virtual line source using the 2-dimensional ESA
@@ -300,8 +300,8 @@ def line_2d_edge_dipole_ssd(omega, x0, xs, alpha=3/2*np.pi, Nc=None, c=None):
     return -1j*np.pi/alpha * d
 
 
-def point_25d_edge(omega, x0, xs, xref=[2, -2, 0], alpha=3/2*np.pi,
-              Nc=None, c=None):
+def point_25d_edge(omega, x0, xs, *, xref=[2, -2, 0], alpha=3/2*np.pi,
+                   Nc=None, c=None):
     r"""Driving function for 2.5-dimensional point source with edge ESA.
 
     Driving function for a virtual point source using the 2.5-dimensional

--- a/sfs/fd/nfchoa.py
+++ b/sfs/fd/nfchoa.py
@@ -35,7 +35,7 @@ from .. import util
 from . import secondary_source_point
 
 
-def plane_2d(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
+def plane_2d(omega, x0, r0, n=[0, 1, 0], *, max_order=None, c=None):
     r"""Driving function for 2-dimensional NFC-HOA for a virtual plane wave.
 
     Parameters
@@ -101,7 +101,7 @@ def plane_2d(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
     return -2j / (np.pi*r0) * d, selection, secondary_source_point(omega, c)
 
 
-def point_25d(omega, x0, r0, xs, max_order=None, c=None):
+def point_25d(omega, x0, r0, xs, *, max_order=None, c=None):
     r"""Driving function for 2.5-dimensional NFC-HOA for a virtual point source.
 
     Parameters
@@ -169,7 +169,7 @@ def point_25d(omega, x0, r0, xs, max_order=None, c=None):
     return d / (2 * np.pi * r0), selection, secondary_source_point(omega, c)
 
 
-def plane_25d(omega, x0, r0, n=[0, 1, 0], max_order=None, c=None):
+def plane_25d(omega, x0, r0, n=[0, 1, 0], *, max_order=None, c=None):
     r"""Driving function for 2.5-dimensional NFC-HOA for a virtual plane wave.
 
     Parameters

--- a/sfs/fd/sdm.py
+++ b/sfs/fd/sdm.py
@@ -34,7 +34,7 @@ from .. import util
 from . import secondary_source_line, secondary_source_point
 
 
-def line_2d(omega, x0, n0, xs, c=None):
+def line_2d(omega, x0, n0, xs, *, c=None):
     r"""Driving function for 2-dimensional SDM for a virtual line source.
 
     Parameters
@@ -87,7 +87,7 @@ def line_2d(omega, x0, n0, xs, c=None):
     return d, selection, secondary_source_line(omega, c)
 
 
-def plane_2d(omega, x0, n0, n=[0, 1, 0], c=None):
+def plane_2d(omega, x0, n0, n=[0, 1, 0], *, c=None):
     r"""Driving function for 2-dimensional SDM for a virtual plane wave.
 
     Parameters
@@ -142,7 +142,7 @@ def plane_2d(omega, x0, n0, n=[0, 1, 0], c=None):
     return d, selection, secondary_source_line(omega, c)
 
 
-def plane_25d(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
+def plane_25d(omega, x0, n0, n=[0, 1, 0], *, xref=[0, 0, 0], c=None):
     r"""Driving function for 2.5-dimensional SDM for a virtual plane wave.
 
     Parameters
@@ -182,7 +182,7 @@ def plane_25d(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
         :context: close-figs
 
         d, selection, secondary_source = sfs.fd.sdm.plane_25d(
-            omega, array.x, array.n, npw, [0, -1, 0])
+            omega, array.x, array.n, npw, xref=[0, -1, 0])
         plot(d, selection, secondary_source)
 
     """
@@ -197,7 +197,7 @@ def plane_25d(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
     return d, selection, secondary_source_point(omega, c)
 
 
-def point_25d(omega, x0, n0, xs, xref=[0, 0, 0], c=None):
+def point_25d(omega, x0, n0, xs, *, xref=[0, 0, 0], c=None):
     r"""Driving function for 2.5-dimensional SDM for a virtual point source.
 
     Parameters
@@ -237,7 +237,7 @@ def point_25d(omega, x0, n0, xs, xref=[0, 0, 0], c=None):
         :context: close-figs
 
         d, selection, secondary_source = sfs.fd.sdm.point_25d(
-            omega, array.x, array.n, xs, [0, -1, 0])
+            omega, array.x, array.n, xs, xref=[0, -1, 0])
         plot(d, selection, secondary_source)
 
     """

--- a/sfs/fd/source.py
+++ b/sfs/fd/source.py
@@ -32,7 +32,7 @@ from .. import util
 from .. import default
 
 
-def point(omega, x0, grid, c=None):
+def point(omega, x0, grid, *, c=None):
     r"""Sound pressure of a point source.
 
     Parameters
@@ -85,7 +85,7 @@ def point(omega, x0, grid, c=None):
     return 1 / (4*np.pi) * np.exp(-1j * k * r) / r
 
 
-def point_velocity(omega, x0, grid, c=None, rho0=None):
+def point_velocity(omega, x0, grid, *, c=None, rho0=None):
     """Particle velocity of a point source.
 
     Parameters
@@ -134,7 +134,7 @@ def point_velocity(omega, x0, grid, c=None, rho0=None):
     return util.XyzComponents([v * o / r for o in offset])
 
 
-def point_averaged_intensity(omega, x0, grid, c=None, rho0=None):
+def point_averaged_intensity(omega, x0, grid, *, c=None, rho0=None):
     """Velocity of a point source.
 
     Parameters
@@ -169,7 +169,7 @@ def point_averaged_intensity(omega, x0, grid, c=None, rho0=None):
     return util.XyzComponents([i * o / r**2 for o in offset])
 
 
-def point_dipole(omega, x0, n0, grid, c=None):
+def point_dipole(omega, x0, n0, grid, *, c=None):
     r"""Point source with dipole characteristics.
 
     Parameters
@@ -221,7 +221,7 @@ def point_dipole(omega, x0, n0, grid, c=None):
         np.power(r, 2) * np.exp(-1j * k * r)
 
 
-def point_modal(omega, x0, grid, L, N=None, deltan=0, c=None):
+def point_modal(omega, x0, grid, L, *, N=None, deltan=0, c=None):
     """Point source in a rectangular room using a modal room model.
 
     Parameters
@@ -286,7 +286,7 @@ def point_modal(omega, x0, grid, L, N=None, deltan=0, c=None):
     return p
 
 
-def point_modal_velocity(omega, x0, grid, L, N=None, deltan=0, c=None):
+def point_modal_velocity(omega, x0, grid, L, *, N=None, deltan=0, c=None):
     """Velocity of point source in a rectangular room using a modal room model.
 
     Parameters
@@ -358,7 +358,7 @@ def point_modal_velocity(omega, x0, grid, L, N=None, deltan=0, c=None):
     return util.XyzComponents([vx, vy, vz])
 
 
-def point_image_sources(omega, x0, grid, L, max_order, coeffs=None, c=None):
+def point_image_sources(omega, x0, grid, L, *, max_order, coeffs=None, c=None):
     """Point source in a rectangular room using the mirror image source model.
 
     Parameters
@@ -395,12 +395,12 @@ def point_image_sources(omega, x0, grid, L, max_order, coeffs=None, c=None):
     p = 0
     for position, strength in zip(xs, source_strengths):
         if strength != 0:
-            p += strength * point(omega, position, grid, c)
+            p += strength * point(omega, position, grid, c=c)
 
     return p
 
 
-def line(omega, x0, grid, c=None):
+def line(omega, x0, grid, *, c=None):
     r"""Line source parallel to the z-axis.
 
     Note: third component of x0 is ignored.
@@ -439,7 +439,7 @@ def line(omega, x0, grid, c=None):
     return _duplicate_zdirection(p, grid)
 
 
-def line_velocity(omega, x0, grid, c=None, rho0=None):
+def line_velocity(omega, x0, grid, *, c=None, rho0=None):
     """Velocity of line source parallel to the z-axis.
 
     Returns
@@ -481,7 +481,7 @@ def line_velocity(omega, x0, grid, c=None, rho0=None):
     return util.XyzComponents([_duplicate_zdirection(vi, grid) for vi in v])
 
 
-def line_dipole(omega, x0, n0, grid, c=None):
+def line_dipole(omega, x0, n0, grid, *, c=None):
     r"""Line source with dipole characteristics parallel to the z-axis.
 
     Note: third component of x0 is ignored.
@@ -504,7 +504,7 @@ def line_dipole(omega, x0, n0, grid, c=None):
     return _duplicate_zdirection(p, grid)
 
 
-def line_dirichlet_edge(omega, x0, grid, alpha=3/2*np.pi, Nc=None, c=None):
+def line_dirichlet_edge(omega, x0, grid, *, alpha=3/2*np.pi, Nc=None, c=None):
     """Line source scattered at an edge with Dirichlet boundary conditions.
 
     :cite:`Moser2012`, eq.(10.18/19)
@@ -570,7 +570,7 @@ def line_dirichlet_edge(omega, x0, grid, alpha=3/2*np.pi, Nc=None, c=None):
     return p
 
 
-def plane(omega, x0, n0, grid, c=None):
+def plane(omega, x0, n0, grid, *, c=None):
     r"""Plane wave.
 
     Parameters
@@ -617,7 +617,7 @@ def plane(omega, x0, n0, grid, c=None):
     return np.exp(-1j * k * np.inner(grid - x0, n0))
 
 
-def plane_velocity(omega, x0, n0, grid, c=None, rho0=None):
+def plane_velocity(omega, x0, n0, grid, *, c=None, rho0=None):
     r"""Velocity of a plane wave.
 
     Parameters
@@ -668,7 +668,7 @@ def plane_velocity(omega, x0, n0, grid, c=None, rho0=None):
     return util.XyzComponents([v * n for n in n0])
 
 
-def plane_averaged_intensity(omega, x0, n0, grid, c=None, rho0=None):
+def plane_averaged_intensity(omega, x0, n0, grid, *, c=None, rho0=None):
     r"""Averaged intensity of a plane wave.
 
     Parameters
@@ -707,7 +707,7 @@ def plane_averaged_intensity(omega, x0, n0, grid, c=None, rho0=None):
     return util.XyzComponents([i * n for n in n0])
 
 
-def pulsating_sphere(omega, center, radius, amplitude, grid, inside=False,
+def pulsating_sphere(omega, center, radius, amplitude, grid, *, inside=False,
                      c=None):
     """Sound pressure of a pulsating sphere.
 
@@ -765,7 +765,8 @@ def pulsating_sphere(omega, center, radius, amplitude, grid, inside=False,
     return impedance * radial_velocity
 
 
-def pulsating_sphere_velocity(omega, center, radius, amplitude, grid, c=None):
+def pulsating_sphere_velocity(omega, center, radius, amplitude, grid, *,
+                              c=None):
     """Particle velocity of a pulsating sphere.
 
     Parameters

--- a/sfs/fd/wfs.py
+++ b/sfs/fd/wfs.py
@@ -39,7 +39,7 @@ from .. import util
 from . import secondary_source_line, secondary_source_point
 
 
-def line_2d(omega, x0, n0, xs, c=None):
+def line_2d(omega, x0, n0, xs, *, c=None):
     r"""Driving function for 2-dimensional WFS for a virtual line source.
 
     Parameters
@@ -95,7 +95,7 @@ def line_2d(omega, x0, n0, xs, c=None):
     return d, selection, secondary_source_line(omega, c)
 
 
-def _point(omega, x0, n0, xs, c=None):
+def _point(omega, x0, n0, xs, *, c=None):
     r"""Driving function for 2/3-dimensional WFS for a virtual point source.
 
     Parameters
@@ -322,7 +322,7 @@ def point_25d_legacy(omega, x0, n0, xs, xref=[0, 0, 0], c=None, omalias=None):
     return d, selection, secondary_source_point(omega, c)
 
 
-def _plane(omega, x0, n0, n=[0, 1, 0], c=None):
+def _plane(omega, x0, n0, n=[0, 1, 0], *, c=None):
     r"""Driving function for 2/3-dimensional WFS for a virtual plane wave.
 
     Parameters
@@ -380,7 +380,7 @@ def _plane(omega, x0, n0, n=[0, 1, 0], c=None):
 plane_2d = _plane
 
 
-def plane_25d(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None,
+def plane_25d(omega, x0, n0, n=[0, 1, 0], *, xref=[0, 0, 0], c=None,
               omalias=None):
     r"""Driving function for 2.5-dimensional WFS for a virtual plane wave.
 
@@ -446,7 +446,7 @@ def plane_25d(omega, x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None,
 plane_3d = _plane
 
 
-def _focused(omega, x0, n0, xs, ns, c=None):
+def _focused(omega, x0, n0, xs, ns, *, c=None):
     r"""Driving function for 2/3-dimensional WFS for a focused source.
 
     Parameters
@@ -507,7 +507,7 @@ def _focused(omega, x0, n0, xs, ns, c=None):
 focused_2d = _focused
 
 
-def focused_25d(omega, x0, n0, xs, ns, xref=[0, 0, 0], c=None,
+def focused_25d(omega, x0, n0, xs, ns, *, xref=[0, 0, 0], c=None,
                 omalias=None):
     r"""Driving function for 2.5-dimensional WFS for a focused source.
 
@@ -615,7 +615,7 @@ def preeq_25d(omega, omalias, c):
             return np.sqrt(1j * util.wavenumber(omalias, c))
 
 
-def plane_3d_delay(omega, x0, n0, n=[0, 1, 0], c=None):
+def plane_3d_delay(omega, x0, n0, n=[0, 1, 0], *, c=None):
     r"""Delay-only driving function for a virtual plane wave.
 
     Parameters
@@ -666,7 +666,7 @@ def plane_3d_delay(omega, x0, n0, n=[0, 1, 0], c=None):
     return d, selection, secondary_source_point(omega, c)
 
 
-def soundfigure_3d(omega, x0, n0, figure, npw=[0, 0, 1], c=None):
+def soundfigure_3d(omega, x0, n0, figure, npw=[0, 0, 1], *, c=None):
     """Compute driving function for a 2D sound figure.
 
     Based on
@@ -701,7 +701,7 @@ def soundfigure_3d(omega, x0, n0, figure, npw=[0, 0, 1], c=None):
                 npw = npw / np.linalg.norm(npw)
                 # driving function of plane wave with positive kz
                 d_component, selection, secondary_source = plane_3d(
-                    omega, x0, n0, npw, c)
+                    omega, x0, n0, npw, c=c)
                 d += selection * figure[n, m] * d_component
 
     return d, util.source_selection_all(len(d)), secondary_source

--- a/sfs/plot2d.py
+++ b/sfs/plot2d.py
@@ -41,7 +41,7 @@ def _register_cmap_transparent(name, color):
 _register_cmap_transparent('blacktransparent', 'black')
 
 
-def virtualsource(xs, ns=None, type='point', ax=None):
+def virtualsource(xs, ns=None, type='point', *, ax=None):
     """Draw position/orientation of virtual source."""
     xs = np.asarray(xs)
     ns = np.asarray(ns)
@@ -61,7 +61,7 @@ def virtualsource(xs, ns=None, type='point', ax=None):
                  head_length=0.1, fc='k', ec='k')
 
 
-def reference(xref, size=0.1, ax=None):
+def reference(xref, *, size=0.1, ax=None):
     """Draw reference/normalization point."""
     xref = np.asarray(xref)
     if ax is None:
@@ -71,7 +71,7 @@ def reference(xref, size=0.1, ax=None):
     ax.plot((xref[0]-size, xref[0]+size), (xref[1]+size, xref[1]-size), 'k-')
 
 
-def secondary_sources(x0, n0, grid=None):
+def secondary_sources(x0, n0, *, grid=None):
     """Simple plot of secondary source locations."""
     x0 = np.asarray(x0)
     n0 = np.asarray(n0)
@@ -87,7 +87,7 @@ def secondary_sources(x0, n0, grid=None):
         ax.add_artist(ss)
 
 
-def loudspeakers(x0, n0, a0=0.5, size=0.08, show_numbers=False, grid=None,
+def loudspeakers(x0, n0, a0=0.5, *, size=0.08, show_numbers=False, grid=None,
                  ax=None):
     """Draw loudspeaker symbols at given locations and angles.
 
@@ -164,9 +164,9 @@ def _visible_secondarysources(x0, n0, grid):
     return x0[idx, :], n0[idx, :]
 
 
-def amplitude(p, grid, xnorm=None, cmap='coolwarm_clip', vmin=-2.0, vmax=2.0,
-              xlabel=None, ylabel=None, colorbar=True, colorbar_kwargs={},
-              ax=None, **kwargs):
+def amplitude(p, grid, *, xnorm=None, cmap='coolwarm_clip',
+              vmin=-2.0, vmax=2.0, xlabel=None, ylabel=None,
+              colorbar=True, colorbar_kwargs={}, ax=None, **kwargs):
     """Two-dimensional plot of sound field (real part).
 
     Parameters
@@ -294,7 +294,7 @@ def amplitude(p, grid, xnorm=None, cmap='coolwarm_clip', vmin=-2.0, vmax=2.0,
     return im
 
 
-def level(p, grid, xnorm=None, power=False, cmap=None, vmax=3, vmin=-50,
+def level(p, grid, *, xnorm=None, power=False, cmap=None, vmax=3, vmin=-50,
           **kwargs):
     """Two-dimensional plot of level (dB) of sound field.
 
@@ -314,7 +314,7 @@ def level(p, grid, xnorm=None, power=False, cmap=None, vmax=3, vmin=-50,
                      vmax=vmax, vmin=vmin, **kwargs)
 
 
-def particles(x, trim=None, ax=None, xlabel='x (m)', ylabel='y (m)',
+def particles(x, *, trim=None, ax=None, xlabel='x (m)', ylabel='y (m)',
               edgecolor='', marker='.', s=15, **kwargs):
     """Plot particle positions as scatter plot"""
     XX, YY = [np.real(c) for c in x[:2]]
@@ -337,8 +337,8 @@ def particles(x, trim=None, ax=None, xlabel='x (m)', ylabel='y (m)',
                       **kwargs)
 
 
-def vectors(v, grid, cmap='blacktransparent', headlength=3, headaxislength=2.5,
-            ax=None, clim=None, **kwargs):
+def vectors(v, grid, *, cmap='blacktransparent', headlength=3,
+            headaxislength=2.5, ax=None, clim=None, **kwargs):
     """Plot a vector field in the xy plane.
 
     Parameters
@@ -384,7 +384,7 @@ def vectors(v, grid, cmap='blacktransparent', headlength=3, headaxislength=2.5,
                      headaxislength=headaxislength, clim=clim, **kwargs)
 
 
-def add_colorbar(im, aspect=20, pad=0.5, **kwargs):
+def add_colorbar(im, *, aspect=20, pad=0.5, **kwargs):
     r"""Add a vertical color bar to a plot.
 
     Parameters

--- a/sfs/plot3d.py
+++ b/sfs/plot3d.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 
 
-def secondary_sources(x0, n0, a0=None, w=0.08, h=0.08):
+def secondary_sources(x0, n0, a0=None, *, w=0.08, h=0.08):
     """Plot positions and normals of a 3D secondary source distribution."""
     fig = plt.figure(figsize=(15, 15))
     ax = fig.add_subplot(111, projection='3d')

--- a/sfs/tapering.py
+++ b/sfs/tapering.py
@@ -51,7 +51,7 @@ def none(active):
     return active
 
 
-def tukey(active, alpha):
+def tukey(active, *, alpha):
     """Tukey tapering window.
 
     This uses a function similar to :func:`scipy.signal.tukey`, except
@@ -75,18 +75,18 @@ def tukey(active, alpha):
     .. plot::
         :context: close-figs
 
-        plt.plot(sfs.tapering.tukey(active1, 0), label='alpha = 0')
-        plt.plot(sfs.tapering.tukey(active1, 0.25), label='alpha = 0.25')
-        plt.plot(sfs.tapering.tukey(active1, 0.5), label='alpha = 0.5')
-        plt.plot(sfs.tapering.tukey(active1, 0.75), label='alpha = 0.75')
-        plt.plot(sfs.tapering.tukey(active1, 1), label='alpha = 1')
+        plt.plot(sfs.tapering.tukey(active1, alpha=0), label='alpha = 0')
+        plt.plot(sfs.tapering.tukey(active1, alpha=0.25), label='alpha = 0.25')
+        plt.plot(sfs.tapering.tukey(active1, alpha=0.5), label='alpha = 0.5')
+        plt.plot(sfs.tapering.tukey(active1, alpha=0.75), label='alpha = 0.75')
+        plt.plot(sfs.tapering.tukey(active1, alpha=1), label='alpha = 1')
         plt.axis([-3, 103, -0.1, 1.1])
         plt.legend(loc='lower center')
 
     .. plot::
         :context: close-figs
 
-        plt.plot(sfs.tapering.tukey(active2, 0.3))
+        plt.plot(sfs.tapering.tukey(active2, alpha=0.3))
         plt.axis([-3, 103, -0.1, 1.1])
 
     """
@@ -109,7 +109,7 @@ def tukey(active, alpha):
     return result
 
 
-def kaiser(active, beta):
+def kaiser(active, *, beta):
     """Kaiser tapering window.
 
     This uses :func:`numpy.kaiser`.
@@ -131,18 +131,18 @@ def kaiser(active, beta):
     .. plot::
         :context: close-figs
 
-        plt.plot(sfs.tapering.kaiser(active1, 0), label='beta = 0')
-        plt.plot(sfs.tapering.kaiser(active1, 2), label='beta = 2')
-        plt.plot(sfs.tapering.kaiser(active1, 6), label='beta = 6')
-        plt.plot(sfs.tapering.kaiser(active1, 8.6), label='beta = 8.6')
-        plt.plot(sfs.tapering.kaiser(active1, 14), label='beta = 14')
+        plt.plot(sfs.tapering.kaiser(active1, beta=0), label='beta = 0')
+        plt.plot(sfs.tapering.kaiser(active1, beta=2), label='beta = 2')
+        plt.plot(sfs.tapering.kaiser(active1, beta=6), label='beta = 6')
+        plt.plot(sfs.tapering.kaiser(active1, beta=8.6), label='beta = 8.6')
+        plt.plot(sfs.tapering.kaiser(active1, beta=14), label='beta = 14')
         plt.axis([-3, 103, -0.1, 1.1])
         plt.legend(loc='lower center')
 
     .. plot::
         :context: close-figs
 
-        plt.plot(sfs.tapering.kaiser(active2, 7))
+        plt.plot(sfs.tapering.kaiser(active2, beta=7))
         plt.axis([-3, 103, -0.1, 1.1])
 
     """

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -230,7 +230,8 @@ def as_delayed_signal(arg, **kwargs):
     raise TypeError('expected audio data, samplerate, optional start time')
 
 
-def strict_arange(start, stop, step=1, endpoint=False, dtype=None, **kwargs):
+def strict_arange(start, stop, step=1, *, endpoint=False, dtype=None,
+                  **kwargs):
     """Like :func:`numpy.arange`, but compensating numeric errors.
 
     Unlike :func:`numpy.arange`, but similar to :func:`numpy.linspace`,
@@ -266,7 +267,7 @@ def strict_arange(start, stop, step=1, endpoint=False, dtype=None, **kwargs):
     return np.arange(start, stop, step, dtype)
 
 
-def xyz_grid(x, y, z, spacing, endpoint=True, **kwargs):
+def xyz_grid(x, y, z, *, spacing, endpoint=True, **kwargs):
     """Create a grid with given range and spacing.
 
     Parameters
@@ -349,7 +350,7 @@ def displacement(v, omega):
     return as_xyz_components(v) / (1j * omega)
 
 
-def db(x, power=False):
+def db(x, *, power=False):
     """Convert *x* to decibel.
 
     Parameters
@@ -477,7 +478,7 @@ If you want to ensure that a given variable contains a valid signal, use
 """
 
 
-def image_sources_for_box(x, L, N, prune=True):
+def image_sources_for_box(x, L, N, *, prune=True):
     """Image source method for a cuboid room.
 
     The classical method by Allen and Berkley :cite:`Allen1979`.


### PR DESCRIPTION
Keyword-only arguments are a nice Python 3 feature to force the user to use keyword arguments, avoiding very long sequences of positional parameters.

The good thing is that if it gets annoying, the requirements can be weakened without causing backwards-compatibility issues.

Adding them is typically backwards-incompatible.