### PR TITLE
DOC: Update existing links to theory

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,6 +41,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.doctest',
     'sphinxcontrib.bibtex',
+    'sphinx.ext.extlinks',
     'matplotlib.sphinxext.plot_directive',
     'nbsphinx',
 ]
@@ -76,6 +77,9 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('https://matplotlib.org/', None),
 }
+
+extlinks = {'sfs': ('https://sfs.readthedocs.io/en/3.2/%s',
+                    'https://sfs.rtfd.io/')}
 
 plot_include_source = True
 plot_html_show_source_link = False

--- a/sfs/fd/nfchoa.py
+++ b/sfs/fd/nfchoa.py
@@ -74,7 +74,7 @@ def plane_2d(omega, x0, r0, n=[0, 1, 0], *, max_order=None, c=None):
         \frac{\i^{-m}}{\Hankel{2}{m}{\wc r_0}}
         \e{\i m (\phi_0 - \phi_\text{pw})}
 
-    See http://sfstoolbox.org/#equation-D.nfchoa.pw.2D.
+    See :sfs:`d_nfchoa/#equation-fd-nfchoa-plane-2d`
 
     Examples
     --------
@@ -140,7 +140,7 @@ def point_25d(omega, x0, r0, xs, *, max_order=None, c=None):
         \frac{\hankel{2}{|m|}{\wc r}}{\hankel{2}{|m|}{\wc r_0}}
         \e{\i m (\phi_0 - \phi)}
 
-    See http://sfstoolbox.org/#equation-D.nfchoa.ps.2.5D.
+    See :sfs:`d_nfchoa/#equation-fd-nfchoa-point-25d`
 
     Examples
     --------
@@ -208,7 +208,7 @@ def plane_25d(omega, x0, r0, n=[0, 1, 0], *, max_order=None, c=None):
         \frac{\i^{-|m|}}{\wc \hankel{2}{|m|}{\wc r_0}}
         \e{\i m (\phi_0 - \phi_\text{pw})}
 
-    See http://sfstoolbox.org/#equation-D.nfchoa.pw.2.5D.
+    See :sfs:`d_nfchoa/#equation-fd-nfchoa-plane-25d`
 
     Examples
     --------

--- a/sfs/td/wfs.py
+++ b/sfs/td/wfs.py
@@ -96,9 +96,7 @@ def plane_25d(x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
 
     with wfs(2.5D) prefilter h(t), which is not implemented yet.
 
-    References
-    ----------
-    See http://sfstoolbox.org/en/latest/#equation-d.wfs.pw.2.5D
+    See :sfs:`d_wfs/#equation-td-wfs-plane-25d`
 
     Examples
     --------
@@ -173,9 +171,7 @@ def point_25d(x0, n0, xs, xref=[0, 0, 0], c=None):
 
     with wfs(2.5D) prefilter h(t), which is not implemented yet.
 
-    References
-    ----------
-    See http://sfstoolbox.org/en/latest/#equation-d.wfs.ps.2.5D
+    See :sfs:`d_wfs/#equation-td-wfs-point-25d`
 
     Examples
     --------
@@ -257,9 +253,7 @@ def focused_25d(x0, n0, xs, ns, xref=[0, 0, 0], c=None):
 
     with wfs(2.5D) prefilter h(t), which is not implemented yet.
 
-    References
-    ----------
-    See http://sfstoolbox.org/en/latest/#equation-d.wfs.fs.2.5D
+    See :sfs:`d_wfs/#equation-td-wfs-focused-25d`
 
     Examples
     --------


### PR DESCRIPTION
This updates the already existing URL references to the theory page to use the new `https://sfs.rtfd.io` address and the new naming scheme of equation labels.

NOTE: version 3.2 of the documentation is not online yet as it requires sfs 0.5.0 to be released first.
I tested the new links by changing `3.2` to `test-rtfd` in `conf.py` which is a version of the documentation build against the current sfs master. I did the test with `python3 setup.py build_sphinx -b linkcheck`.