### PR TITLE
Replace inner1d bei einsum

### DIFF
--- a/sfs/td/wfs.py
+++ b/sfs/td/wfs.py
@@ -44,7 +44,6 @@
 
 """
 import numpy as _np
-from numpy.core.umath_tests import inner1d as _inner1d
 
 from . import apply_delays as _apply_delays
 from . import secondary_source_point as _secondary_source_point
@@ -119,8 +118,8 @@ def plane_25d(x0, n0, n=[0, 1, 0], xref=[0, 0, 0], c=None):
     n = _util.normalize_vector(n)
     xref = _util.asarray_1d(xref)
     g0 = _np.sqrt(2 * _np.pi * _np.linalg.norm(xref - x0, axis=1))
-    delays = _inner1d(n, x0) / c
-    weights = 2 * g0 * _inner1d(n, n0)
+    delays = _np.einsum('i,ji->j', n, x0) / c
+    weights = 2 * g0 * _np.einsum('i,ji->j', n, n0)
     selection = _util.source_selection_plane(n0, n)
     return delays, weights, selection, _secondary_source_point(c)
 
@@ -208,7 +207,7 @@ def point_25d(x0, n0, xs, xref=[0, 0, 0], c=None):
     g0 *= _np.sqrt((x0xs_n*x0xref_n)/(x0xs_n+x0xref_n))
 
     delays = x0xs_n/c
-    weights = g0*_inner1d(x0xs, n0)
+    weights = g0*_np.einsum('ij,ij->i', x0xs, n0)
     selection = _util.source_selection_point(n0, x0, xs)
     return delays, weights, selection, _secondary_source_point(c)
 
@@ -295,8 +294,8 @@ def point_25d_legacy(x0, n0, xs, xref=[0, 0, 0], c=None):
     g0 = _np.sqrt(2 * _np.pi * _np.linalg.norm(xref - x0, axis=1))
     ds = x0 - xs
     r = _np.linalg.norm(ds, axis=1)
-    delays = r/c
-    weights = g0 * _inner1d(ds, n0) / (2 * _np.pi * r**(3/2))
+    delays = r / c
+    weights = g0 * _np.einsum('ij,ij->i', ds, n0) / (2 * _np.pi * r**(3 / 2))
     selection = _util.source_selection_point(n0, x0, xs)
     return delays, weights, selection, _secondary_source_point(c)
 
@@ -378,8 +377,8 @@ def focused_25d(x0, n0, xs, ns, xref=[0, 0, 0], c=None):
     r = _np.linalg.norm(ds, axis=1)
     g0 = _np.sqrt(_np.linalg.norm(xref - x0, axis=1)
                   / (_np.linalg.norm(xref - x0, axis=1) + r))
-    delays = -r/c
-    weights = g0 * _inner1d(ds, n0) / (2 * _np.pi * r**(3/2))
+    delays = -r / c
+    weights = g0 * _np.einsum('ij,ij->i', ds, n0) / (2 * _np.pi * r**(3 / 2))
     selection = _util.source_selection_focused(ns, x0, xs)
     return delays, weights, selection, _secondary_source_point(c)
 

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -6,7 +6,6 @@
 
 import collections
 import numpy as np
-from numpy.core.umath_tests import inner1d
 from scipy.special import spherical_jn, spherical_yn
 from . import default
 
@@ -51,7 +50,7 @@ def wavenumber(omega, c=None):
     return omega / c
 
 
-def direction_vector(alpha, beta=np.pi/2):
+def direction_vector(alpha, beta=np.pi / 2):
     """Compute normal vector from azimuth, colatitude."""
     return sph2cart(alpha, beta, 1)
 
@@ -503,6 +502,7 @@ def image_sources_for_box(x, L, N, *, prune=True):
         number of reflections at individual walls for each source.
 
     """
+
     def _images_1d_unit_box(x, N):
         result = np.arange(-N, N + 1, dtype=x.dtype)
         result[N % 2::2] += x
@@ -510,12 +510,12 @@ def image_sources_for_box(x, L, N, *, prune=True):
         return result
 
     def _count_walls_1d(a):
-        b = np.floor(a/2)
-        c = np.ceil((a-1)/2)
+        b = np.floor(a / 2)
+        c = np.ceil((a - 1) / 2)
         return np.abs(np.stack([b, c], axis=1)).astype(int)
 
     L = asarray_1d(L)
-    x = asarray_1d(x)/L
+    x = asarray_1d(x) / L
     D = len(x)
     xs = [_images_1d_unit_box(coord, N) for coord in x]
     xs = np.reshape(np.transpose(np.meshgrid(*xs, indexing='ij')), (-1, D))
@@ -576,7 +576,7 @@ def source_selection_point(n0, x0, xs):
     x0 = asarray_of_rows(x0)
     xs = asarray_1d(xs)
     ds = x0 - xs
-    return inner1d(ds, n0) >= default.selection_tolerance
+    return np.einsum('ij,ij->i', ds, n0) >= default.selection_tolerance
 
 
 def source_selection_line(n0, x0, xs):
@@ -598,7 +598,7 @@ def source_selection_focused(ns, x0, xs):
     xs = asarray_1d(xs)
     ns = normalize_vector(ns)
     ds = xs - x0
-    return inner1d(ns, ds) >= default.selection_tolerance
+    return np.einsum('i,ji->j', ns, ds) >= default.selection_tolerance
 
 
 def source_selection_all(N):


### PR DESCRIPTION
We use
`from numpy.core.umath_tests import inner1d as _inner1d`
which is suboptimal, since its deprecated and requires non-standard library import.
See also https://github.com/sfstoolbox/sfs-python/issues/77

We could use numpy's `einsum` do to this job instead, thus I've changed (hopefully) all occurrences of `inner1d` to `einsum`.

Besides that in the files, some PEP8 modifications were done, these suggestions came from PyCharm.

Maybe numpy's `tensordot` is even more performant/suitable. I don't know currently how/if these functions support parallel computation, which `inner1d` seemed to do and was chosen for. I will check this.

In the meantime, using `einsum` in this PR is definitely an improvement for the code.