### PR TITLE
DOC: add compatibility for sphinxcontrib-bibtex>=2

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,8 @@ extensions = [
     'nbsphinx',
 ]
 
+bibtex_bibfiles = ['references.bib']
+
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
     "--InlineBackend.rc={'figure.dpi': 96}",

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -3,4 +3,3 @@ References
 
 .. bibliography::
     :style: alpha
-    :all:

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -1,6 +1,6 @@
 References
 ==========
 
-.. bibliography:: references.bib
+.. bibliography::
     :style: alpha
     :all:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,7 @@ Sphinx>=1.3.6
 Sphinx-RTD-Theme
 nbsphinx
 ipykernel
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex>=2.1.4
 
 NumPy
 SciPy

--- a/sfs/util.py
+++ b/sfs/util.py
@@ -610,7 +610,7 @@ def max_order_circular_harmonics(N):
     r"""Maximum order of 2D/2.5D HOA.
 
     It returns the maximum order for which no spatial aliasing appears.
-    It is given on page 132 of [Ahrens2012]_ as
+    It is given on page 132 of :cite:`Ahrens2012` as
 
     .. math::
         \mathtt{max\_order} =


### PR DESCRIPTION
the test in https://github.com/sfstoolbox/sfs-python/pull/168 are failing as `sphinxcontrib-bibtex` introduced a breaing change with version 2.0.0 as you have to add another config setting.

This fixes thie issue.