### PR TITLE
Use "nearest" interpolation for level() plots by default

### DIFF
--- a/sfs/plot2d.py
+++ b/sfs/plot2d.py
@@ -310,7 +310,7 @@ def amplitude(p, grid, *, xnorm=None, cmap='coolwarm_clip',
 
 
 def level(p, grid, *, xnorm=None, power=False, cmap=None, vmax=3, vmin=-50,
-          **kwargs):
+          interpolation='nearest', **kwargs):
     """Two-dimensional plot of level (dB) of sound field.
 
     Takes the same parameters as `sfs.plot2d.amplitude()`.
@@ -325,8 +325,9 @@ def level(p, grid, *, xnorm=None, power=False, cmap=None, vmax=3, vmin=-50,
     if xnorm is not None:
         p = _util.normalize(p, grid, xnorm)
     L = _util.db(p, power=power)
-    return amplitude(L, grid=grid, xnorm=None, cmap=cmap,
-                     vmax=vmax, vmin=vmin, **kwargs)
+    return amplitude(
+        L, grid=grid, xnorm=None, cmap=cmap, vmax=vmax, vmin=vmin,
+        interpolation=interpolation, **kwargs)
 
 
 def particles(x, *, trim=None, ax=None, xlabel='x (m)', ylabel='y (m)',


### PR DESCRIPTION
Fixes #170.

The plots still don't look great, but at least this restores the previous state.

Apparently, the default was changed to `nearest` in Matplotlib 2.0:

https://matplotlib.org/3.3.3/users/dflt_style_changes.html#interpolation

... and then changed again in 3.2.0 (which is probably the cause for #170):

https://matplotlib.org/3.3.3/api/prev_api_changes/api_changes_3.2.0.html#default-image-interpolation