### PR TITLE
Update readthedocs.yml

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,11 +1,14 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3"
 
 python:
   install:
     - requirements: requirements.txt
     - requirements: doc/requirements.txt
+
+sphinx:
+  configuration: doc/conf.py


### PR DESCRIPTION
- sphinx handling mod https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

- ubuntu/python versions