### PR TITLE
DOC: fix docname in prolog/epilog

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -112,7 +112,7 @@ default_role = 'any'
 pygments_style = 'sphinx'
 
 jinja_define = r"""
-{% set docname = env.doc2path(env.docname, base='doc') %}
+{% set docname = 'doc/' + env.doc2path(env.docname, base=False)|string %}
 {% set latex_href = ''.join([
     '\href{https://github.com/sfstoolbox/sfs-python/blob/',
     env.config.release,


### PR DESCRIPTION
Apparently, the API of `doc2path()` was changed a long time ago and the old behavior was removed in Sphinx 4 (https://github.com/sphinx-doc/sphinx/pull/7416).

This led to incorrect links at the top of notebooks.