### PR TITLE
Add util.normalize_rows()

### DIFF
--- a/sfs/util.py
+++ b/sfs/util.py
@@ -338,6 +338,12 @@ def normalize_vector(x):
     return x / np.linalg.norm(x)
 
 
+def normalize_rows(x):
+    """Normalize a list of vectors."""
+    x = asarray_of_rows(x)
+    return x / np.linalg.norm(x, axis=1, keepdims=True)
+
+
 def db(x, *, power=False):
     """Convert *x* to decibel.
 


### PR DESCRIPTION
Originally, I wanted to extend the `normalize_vector()` function with this functionality, but I didn't find a nice way to restore the original array dimensions in case a 1D array is given (which is basically the main usage until now).

Anyway, it might be better to be more explicit about which axis is used for normalization.